### PR TITLE
CAPI1010 addressing Issue50

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules
 .recommenders/
 */target/
 .nyc_output/
+npm-debug.log

--- a/platform_services/components/crud/getList.js
+++ b/platform_services/components/crud/getList.js
@@ -23,6 +23,7 @@
 **/
 
 const utils = require("../utils.js")();
+const _ = require("lodash");
 
 module.exports = (query, getAllRecords, onComplete) => {
     // initialize dynamodb
@@ -83,7 +84,7 @@ module.exports = (query, getAllRecords, onComplete) => {
 		});
     }
 
-    if (!getAllRecords) {
+    if ((global.userId && !_.includes(global.config.admin_users, global.userId.toLowerCase())) || !getAllRecords) {
         var ddb_created_by = utils.getDatabaseKeyName("created_by");
 
         // filter for services created by current user

--- a/platform_services/components/crud/getList.js
+++ b/platform_services/components/crud/getList.js
@@ -25,7 +25,7 @@
 const utils = require("../utils.js")();
 const _ = require("lodash");
 
-module.exports = (query, onComplete) => {
+module.exports = (query, method, onComplete) => {
     // initialize dynamodb
     var dynamodb = utils.initDynamodb();
 
@@ -84,7 +84,7 @@ module.exports = (query, onComplete) => {
 		});
     }
 
-    //if (global.userId && !_.includes(global.config.admin_users, global.userId.toLowerCase())) {
+    if (global.userId && !_.includes(global.config.admin_users, global.userId.toLowerCase()) || method === 'GET') {
         var ddb_created_by = utils.getDatabaseKeyName("created_by");
 
         // filter for services created by current user
@@ -92,7 +92,7 @@ module.exports = (query, onComplete) => {
         attributeValues[(":" + ddb_created_by)] = {
             'S': global.userId
         };
-    //}
+    }
 
     if (filter !== "") {
         filter = filter.substring(0, filter.length - insertAnd.length); // remove insertAnd at the end

--- a/platform_services/components/crud/getList.js
+++ b/platform_services/components/crud/getList.js
@@ -25,7 +25,6 @@
 const utils = require("../utils.js")();
 
 module.exports = (query, getAllRecords, onComplete) => {
-  console.log(getAllRecords);
     // initialize dynamodb
     var dynamodb = utils.initDynamodb();
 

--- a/platform_services/components/crud/getList.js
+++ b/platform_services/components/crud/getList.js
@@ -84,7 +84,7 @@ module.exports = (query, getAllRecords, onComplete) => {
 		});
     }
 
-    if ((global.userId && !_.includes(global.config.admin_users, global.userId.toLowerCase())) || !getAllRecords) {
+    if (!getAllRecords || (global.userId && !_.includes(global.config.admin_users, global.userId.toLowerCase()))) {
         var ddb_created_by = utils.getDatabaseKeyName("created_by");
 
         // filter for services created by current user

--- a/platform_services/components/crud/getList.js
+++ b/platform_services/components/crud/getList.js
@@ -1,6 +1,6 @@
 // =========================================================================
 // Copyright � 2017 T-Mobile USA, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -22,7 +22,7 @@
 	@version: 1.0
 **/
 
-const utils = require("../utils.js")(); 
+const utils = require("../utils.js")();
 const _ = require("lodash");
 
 module.exports = (query, onComplete) => {
@@ -40,13 +40,13 @@ module.exports = (query, onComplete) => {
     };
 
     var filter_key = utils.getDatabaseKeyName(global.config.service_filter_key);
-    
+
     if (query !== undefined && query !== null) {
-        
+
         var keys_list = global.config.service_filter_params;
 
         keys_list.forEach(function (key) {
-            
+
 			var key_name = utils.getDatabaseKeyName(key);
 
 			if (key_name == "SERVICE_TIMESTAMP" && (query.last_updated_after !== undefined || query.last_updated_before !== undefined)) {
@@ -80,11 +80,11 @@ module.exports = (query, onComplete) => {
 				attributeValues[(":" + key_name)] = {
 					'S': query[key]
 				};
-			}   
+			}
 		});
     }
 
-    if (global.userId && !_.includes(global.config.admin_users, global.userId.toLowerCase())) {
+    //if (global.userId && !_.includes(global.config.admin_users, global.userId.toLowerCase())) {
         var ddb_created_by = utils.getDatabaseKeyName("created_by");
 
         // filter for services created by current user
@@ -92,7 +92,7 @@ module.exports = (query, onComplete) => {
         attributeValues[(":" + ddb_created_by)] = {
             'S': global.userId
         };
-    }
+    //}
 
     if (filter !== "") {
         filter = filter.substring(0, filter.length - insertAnd.length); // remove insertAnd at the end

--- a/platform_services/components/crud/getList.js
+++ b/platform_services/components/crud/getList.js
@@ -23,9 +23,9 @@
 **/
 
 const utils = require("../utils.js")();
-const _ = require("lodash");
 
-module.exports = (query, method, onComplete) => {
+module.exports = (query, getAllRecords, onComplete) => {
+  console.log(getAllRecords);
     // initialize dynamodb
     var dynamodb = utils.initDynamodb();
 
@@ -84,7 +84,7 @@ module.exports = (query, method, onComplete) => {
 		});
     }
 
-    if (global.userId && !_.includes(global.config.admin_users, global.userId.toLowerCase()) || method === 'GET') {
+    if (!getAllRecords) {
         var ddb_created_by = utils.getDatabaseKeyName("created_by");
 
         // filter for services created by current user

--- a/platform_services/index.js
+++ b/platform_services/index.js
@@ -26,6 +26,7 @@ const configObj = require("./components/config.js");
 const logger = require("./components/logger.js");
 const utils = require("./components/utils.js")();
 const crud = require("./components/crud")();
+const _ = require("lodash");
 
 const async = require('async');
 
@@ -59,6 +60,16 @@ module.exports.handler = (event, context, cb) => {
 
         global.services_table = config.services_table;
         global.userId = event.principalId;
+        var getAllRecords = false;
+        //check if the user has the proper credentials to retrieve all service information based on scenario
+        var getAllCheck = function(eventMethod){
+          //for non admins or for any "get" requests initiated, all services should not be searched.
+          if((global.userId && !_.includes(global.config.admin_users, global.userId.toLowerCase()))
+              || eventMethod === "GET"){
+                return false;
+          }
+          return true;
+        };
 
         // 1: GET service by id (/services/{service_id})
         if (event.method === 'GET' && service_id) {
@@ -95,7 +106,8 @@ module.exports.handler = (event, context, cb) => {
                 // fetch services list from dynamodb, filter if required
                 fetchServices: function(onComplete) {
                     var query = event.query;
-                    crud.getList(query, event.method, onComplete);
+                    getAllRecords = getAllCheck(event.method);
+                    crud.getList(query, getAllRecords, onComplete);
                 }
             }, function(error, result) {
                 // Handle error
@@ -320,7 +332,8 @@ module.exports.handler = (event, context, cb) => {
                 },
                 // Check if a service with same domain and service_name combination exists
                 validateServiceExists: function(onComplete) {
-                    crud.getList({ 'service': service_data.service, 'domain': service_data.domain }, event.method, function onServiceGet(error, data) {
+                    getAllRecords = getAllCheck(event.method);
+                    crud.getList({ 'service': service_data.service, 'domain': service_data.domain }, getAllRecords, function onServiceGet(error, data) {
                         if (error) {
                             onComplete(error, null);
                         } else {

--- a/platform_services/index.js
+++ b/platform_services/index.js
@@ -26,7 +26,6 @@ const configObj = require("./components/config.js");
 const logger = require("./components/logger.js");
 const utils = require("./components/utils.js")();
 const crud = require("./components/crud")();
-const _ = require("lodash");
 
 const async = require('async');
 
@@ -60,16 +59,7 @@ module.exports.handler = (event, context, cb) => {
 
         global.services_table = config.services_table;
         global.userId = event.principalId;
-        var getAllRecords = false;
-        //check if the user has the proper credentials to retrieve all service information based on scenario
-        var getAllCheck = function(eventMethod){
-          //for non admins or for any "get" requests initiated, all services should not be searched.
-          if((global.userId && !_.includes(global.config.admin_users, global.userId.toLowerCase()))
-              || eventMethod === "GET"){
-                return false;
-          }
-          return true;
-        };
+        var getAllRecords;
 
         // 1: GET service by id (/services/{service_id})
         if (event.method === 'GET' && service_id) {
@@ -106,7 +96,7 @@ module.exports.handler = (event, context, cb) => {
                 // fetch services list from dynamodb, filter if required
                 fetchServices: function(onComplete) {
                     var query = event.query;
-                    getAllRecords = getAllCheck(event.method);
+                    getAllRecords = false;
                     crud.getList(query, getAllRecords, onComplete);
                 }
             }, function(error, result) {
@@ -332,7 +322,7 @@ module.exports.handler = (event, context, cb) => {
                 },
                 // Check if a service with same domain and service_name combination exists
                 validateServiceExists: function(onComplete) {
-                    getAllRecords = getAllCheck(event.method);
+                    getAllRecords = true;
                     crud.getList({ 'service': service_data.service, 'domain': service_data.domain }, getAllRecords, function onServiceGet(error, data) {
                         if (error) {
                             onComplete(error, null);

--- a/platform_services/index.js
+++ b/platform_services/index.js
@@ -59,7 +59,7 @@ module.exports.handler = (event, context, cb) => {
 
         global.services_table = config.services_table;
         global.userId = event.principalId;
-                
+
         // 1: GET service by id (/services/{service_id})
         if (event.method === 'GET' && service_id) {
             logger.info('GET service by ID : ' + service_id);
@@ -95,7 +95,7 @@ module.exports.handler = (event, context, cb) => {
                 // fetch services list from dynamodb, filter if required
                 fetchServices: function(onComplete) {
                     var query = event.query;
-                    crud.getList(query, onComplete);
+                    crud.getList(query, event.method, onComplete);
                 }
             }, function(error, result) {
                 // Handle error
@@ -320,7 +320,7 @@ module.exports.handler = (event, context, cb) => {
                 },
                 // Check if a service with same domain and service_name combination exists
                 validateServiceExists: function(onComplete) {
-                    crud.getList({ 'service': service_data.service, 'domain': service_data.domain }, function onServiceGet(error, data) {
+                    crud.getList({ 'service': service_data.service, 'domain': service_data.domain }, event.method, function onServiceGet(error, data) {
                         if (error) {
                             onComplete(error, null);
                         } else {

--- a/platform_services/test/test.js
+++ b/platform_services/test/test.js
@@ -306,7 +306,7 @@ describe('platform_services', function() {
 
     //user that is not listed among admin_users
     var userId = "Mete0ra";
-    
+
     event.principalId = userId;
     var dataType = "S";
     var filterString = "SERVICE_CREATED_BY" + " = :" + "SERVICE_CREATED_BY";
@@ -324,32 +324,32 @@ describe('platform_services', function() {
     assert.isTrue(allCases);
   });
 
-  /*
-  * Given a userID that IS listed among admin_users, a filter is not used for only the user's services
-  * @param {object} event->event.method="GET", event.path.id is undefined
-  * @params {object, function} default aws context, and callback function as defined in beforeEach
-  */
-  it("should return all relevant service data without filtering userID if user is an admin", function(){
-    event.method = "GET";
-    event.path.id = undefined;
-    event.query.created_by = undefined;
-    
-    //user that is listed among admin_users
-    event.principalId = "ecl!psa";
-
-    var filterString = "SERVICE_CREATED_BY" + " = :" + "SERVICE_CREATED_BY";
-    var scanParam = ":SERVICE_CREATED_BY";
-    //mocking DynamoDB.scan, expecting callback to be returned with params (error,data)
-    AWS.mock("DynamoDB", "scan", spy);
-    //trigger spy by calling index.handler()
-    var callFunction = index.handler(event, context, callback);
-    //assigning the item filter values passed to DynamoDB.scan as values to check against
-    var filterExp = spy.args[0][0].FilterExpression;
-    var expAttrVals = spy.args[0][0].ExpressionAttributeValues;
-    var allCases = !filterExp.includes(filterString) && !expAttrVals[scanParam];
-    AWS.restore("DynamoDB");
-    assert.isTrue(allCases);
-  });
+  // /*
+  // * Given a userID that IS listed among admin_users, a filter is not used for only the user's services
+  // * @param {object} event->event.method="GET", event.path.id is undefined
+  // * @params {object, function} default aws context, and callback function as defined in beforeEach
+  // */
+  // it("should return all relevant service data without filtering userID if user is an admin", function(){
+  //   event.method = "GET";
+  //   event.path.id = undefined;
+  //   event.query.created_by = undefined;
+  //
+  //   //user that is listed among admin_users
+  //   event.principalId = "ecl!psa";
+  //
+  //   var filterString = "SERVICE_CREATED_BY" + " = :" + "SERVICE_CREATED_BY";
+  //   var scanParam = ":SERVICE_CREATED_BY";
+  //   //mocking DynamoDB.scan, expecting callback to be returned with params (error,data)
+  //   AWS.mock("DynamoDB", "scan", spy);
+  //   //trigger spy by calling index.handler()
+  //   var callFunction = index.handler(event, context, callback);
+  //   //assigning the item filter values passed to DynamoDB.scan as values to check against
+  //   var filterExp = spy.args[0][0].FilterExpression;
+  //   var expAttrVals = spy.args[0][0].ExpressionAttributeValues;
+  //   var allCases = !filterExp.includes(filterString) && !expAttrVals[scanParam];
+  //   AWS.restore("DynamoDB");
+  //   assert.isTrue(allCases);
+  // });
 
   /*
   * Given a failed attempt at fetching data from DynamoDB, handler() should inform of error


### PR DESCRIPTION
### Requirements

Upon login and entering the services page, admin is able to see all of the services in the database regardless of which user created the service. For this scenario, only grant the admin access to the data for the services created by them, and not by other users. 

### Description of the Change

Current fix applies a db search filter for services created by the current user if the original http method of the request was a "GET," this includes admin users. Admin maintenance of the app/services for updating, creating, and deleting should still be in place unless they are also called by "GET."

### Benefits

TODO

### Concerns

Could affect Jenkins builds concerning copying, deleting, or updating existing services. 
