### PR TITLE
Event Source mapping deletion Fix.

### DIFF
--- a/build-deploy-platform-services/Jenkinsfile
+++ b/build-deploy-platform-services/Jenkinsfile
@@ -367,7 +367,7 @@ node {
 			}
 
 			if ( (service_template.trim() == "platform-services-handler") ) {
-				def function_name =  env.env_name_prefix + "-hndlr-dev"
+				def function_name =  var_env_name_prefix + "-hndlr-dev"
 				def event_source_list = sh (
 					script: "aws lambda list-event-source-mappings --query \"EventSourceMappings[?contains(FunctionArn, '$function_name')]\" --region \"$region\"" ,
 					returnStdout: true

--- a/build-deploy-platform-services/Jenkinsfile
+++ b/build-deploy-platform-services/Jenkinsfile
@@ -374,7 +374,7 @@ node {
 				).trim()
 				echo "$event_source_list"
 				if (event_source_list == "[]"){
-					sh "aws lambda  create-event-source-mapping --event-source-arn arn:aws:kinesis:$region:$roleId:stream/" + var_env_name_prefix + "-events-hub-dev --function-name arn:aws:lambda:$region:$roleId:function:" + env.env_name_prefix + "-hndlr-dev --starting-position LATEST --region " + region
+					sh "aws lambda  create-event-source-mapping --event-source-arn arn:aws:kinesis:$region:$roleId:stream/" + var_env_name_prefix + "-events-hub-dev --function-name arn:aws:lambda:$region:$roleId:function:$function_name --starting-position LATEST --region " + region
 				}
 			}
 			

--- a/build-deploy-platform-services/Jenkinsfile
+++ b/build-deploy-platform-services/Jenkinsfile
@@ -374,7 +374,7 @@ node {
 				).trim()
 				echo "$event_source_list"
 				if (event_source_list == "[]"){
-					sh "aws lambda  create-event-source-mapping --event-source-arn arn:aws:kinesis:$region:$roleId:stream/" + env.env_name_prefix + "-events-hub-dev --function-name arn:aws:lambda:$region:$roleId:function:" + env.env_name_prefix + "-hndlr-dev --starting-position LATEST --region " + region
+					sh "aws lambda  create-event-source-mapping --event-source-arn arn:aws:kinesis:$region:$roleId:stream/" + var_env_name_prefix + "-events-hub-dev --function-name arn:aws:lambda:$region:$roleId:function:" + env.env_name_prefix + "-hndlr-dev --starting-position LATEST --region " + region
 				}
 			}
 			

--- a/build-deploy-platform-services/Jenkinsfile
+++ b/build-deploy-platform-services/Jenkinsfile
@@ -340,10 +340,16 @@ node {
 			}
 
 			if ( (service_template.trim() == "platform-services-handler") ) {
-          
-				sh "aws lambda  create-event-source-mapping --event-source-arn arn:aws:kinesis:$region:$roleId:stream/" + env.env_name_prefix + "-events-hub-dev --function-name arn:aws:lambda:$region:$roleId:function:" + env.env_name_prefix + "-hndlr-dev --starting-position LATEST --region " + region
+				def function_name =  env.env_name_prefix + "-hndlr-dev"
+				def event_source_list = sh (
+					script: "aws lambda list-event-source-mappings --query \"EventSourceMappings[?contains(FunctionArn, '$function_name')]\" --region \"$region\"" ,
+					returnStdout: true
+				).trim()
+				echo "$event_source_list"
+				if (event_source_list == "[]"){
+					sh "aws lambda  create-event-source-mapping --event-source-arn arn:aws:kinesis:$region:$roleId:stream/" + env.env_name_prefix + "-events-hub-dev --function-name arn:aws:lambda:$region:$roleId:function:" + env.env_name_prefix + "-hndlr-dev --starting-position LATEST --region " + region
+				}
 			}
-
 			
 			// @TODO : Resetting the credentials needs to be introduced. (Re-use of same profile on Async calls needs to be considered)
 			// resetCredentials();


### PR DESCRIPTION
### Requirements

This is a bug, when building the stack with same name the second time after we delete the stack causes build issues. The platform services fails with the below error.

An error occurred (ResourceConflictException) when calling the CreateEventSourceMapping operation: The event source arn (arn:aws:kinesis:us-east-1:108206174331:stream/jazz20171210-events-hub-dev) and function (jazz20171210-hndlr-dev) provided mapping already exists. Please update or delete the existing mapping with UUID 106257e3-ec6a-4fb2-af2d-f26f163a603d

### Description of the Change

This is a bug building the stack with same name the second time after we delete the stack causes build issues. The platform services fails with the below error.

An error occurred (ResourceConflictException) when calling the CreateEventSourceMapping operation: The event source arn (arn:aws:kinesis:us-east-1:108206174331:stream/jazz20171210-events-hub-dev) and function (jazz20171210-hndlr-dev) provided mapping already exists. Please update or delete the existing mapping with UUID 106257e3-ec6a-4fb2-af2d-f26f163a603d


### Benefits

platform services would be build correctly when the stack is created with same name on same day

### Possible Drawbacks

NA

### Applicable Issues

NA
