### PR TITLE
Changing env dependencies for the configModule to params

### DIFF
--- a/api-template-java/Jenkinsfile
+++ b/api-template-java/Jenkinsfile
@@ -1,21 +1,57 @@
 #!groovy
 import groovy.json.JsonOutput
+import groovy.transform.Field
+
+@Field def configModule
+@Field def configLoader
+@Field def jenkins_credential_id
+@Field def api_build_uri_dev
+@Field def api_build_uri
+
+
 node {
 
-withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.JENKINS_CREDENTIAL_ID, passwordVariable: 'PWD', 
+loadConfigModule(params.config_module_url)
+jenkins_credential_id = configLoader.JENKINS.JENKINS_CREDENTIAL_ID
+api_build_uri = configLoader.API.API_BUILD_URI
+api_build_uri_dev = configLoader.API.API_BUILD_URI_DEV
+
+withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: jenkins_credential_id, passwordVariable: 'PWD',
 usernameVariable: 'UNAME']]){
-    
+
    echo "Build triggered via branch::${env.BRANCH_NAME}"
    echo "params : $params"
-  
-   def build_job = env.API_BUILD_URI_DEV
+
+   def build_job = api_build_uri_dev
     if ( env.BRANCH_NAME == 'master') {
-      build_job = env.API_BUILD_URI
-    }  
+      build_job = api_build_uri
+    }
    def var_job_url = JenkinsLocationConfiguration.get().getUrl() + build_job
-  
+
     sh "curl -X GET -k -v -u \"$UNAME:$PWD\"  \"" + var_job_url + "&service_name={service_name}&domain={domain}&scm_branch=${env.BRANCH_NAME}\""
 }
-    
-  
+
+
+}
+
+/*
+* Load environment variables from build module
+*/
+def loadConfigModule(buildModuleUrl){
+	echo "loading env variables, checking repos..."
+
+	dir('config-loader') {
+		checkout([$class: 'GitSCM', branches: [
+			[name: '*/master']
+		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
+		]])
+
+		echo "loading installer variables..."
+
+		def resultJsonString = readFile("jazz-installer-vars.json")
+		configModule = load "config-loader.groovy"
+		configLoader = configModule.initialize(resultJsonString)
+		echo "finished loading env module"
+	}
 }

--- a/api-template-nodejs/Jenkinsfile
+++ b/api-template-nodejs/Jenkinsfile
@@ -1,21 +1,56 @@
 #!groovy
 import groovy.json.JsonOutput
+import groovy.transform.Field
+
+@Field def configModule
+@Field def configLoader
+@Field def jenkins_credential_id
+@Field def api_build_uri_dev
+@Field def api_build_uri
+
 node {
 
-withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.JENKINS_CREDENTIAL_ID, passwordVariable: 'PWD', 
+loadConfigModule(params.config_module_url)
+jenkins_credential_id = configLoader.JENKINS.JENKINS_CREDENTIAL_ID
+api_build_uri = configLoader.API.API_BUILD_URI
+api_build_uri_dev = configLoader.API.API_BUILD_URI_DEV
+
+withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: jenkins_credential_id, passwordVariable: 'PWD',
 usernameVariable: 'UNAME']]){
-    
+
    echo "Build triggered via branch::${env.BRANCH_NAME}"
    echo "params : $params"
-  
-   def build_job = env.API_BUILD_URI_DEV
+
+   def build_job = api_build_uri_dev
     if ( env.BRANCH_NAME == 'master') {
-      build_job = env.API_BUILD_URI
-    }  
+      build_job = api_build_uri
+    }
    def var_job_url = JenkinsLocationConfiguration.get().getUrl() + build_job
-  
+
     sh "curl -X GET -k -v -u \"$UNAME:$PWD\"  \"" + var_job_url + "&service_name={service_name}&domain={domain}&scm_branch=${env.BRANCH_NAME}\""
 }
-    
-  
+
+
+}
+
+/*
+* Load environment variables from build module
+*/
+def loadConfigModule(buildModuleUrl){
+	echo "loading env variables, checking repos..."
+
+	dir('config-loader') {
+		checkout([$class: 'GitSCM', branches: [
+			[name: '*/master']
+		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
+		]])
+
+		echo "loading installer variables..."
+
+		def resultJsonString = readFile("jazz-installer-vars.json")
+		configModule = load "config-loader.groovy"
+		configLoader = configModule.initialize(resultJsonString)
+		echo "finished loading env module"
+	}
 }

--- a/api-template-python/Jenkinsfile
+++ b/api-template-python/Jenkinsfile
@@ -1,21 +1,56 @@
 #!groovy
 import groovy.json.JsonOutput
+import groovy.transform.Field
+
+@Field def configModule
+@Field def configLoader
+@Field def jenkins_credential_id
+@Field def api_build_uri_dev
+@Field def api_build_uri
+
 node {
 
-withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.JENKINS_CREDENTIAL_ID, passwordVariable: 'PWD', 
+loadConfigModule(params.config_module_url)
+jenkins_credential_id = configLoader.JENKINS.JENKINS_CREDENTIAL_ID
+api_build_uri = configLoader.API.API_BUILD_URI
+api_build_uri_dev = configLoader.API.API_BUILD_URI_DEV
+
+withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: jenkins_credential_id, passwordVariable: 'PWD',
 usernameVariable: 'UNAME']]){
-    
+
    echo "Build triggered via branch::${env.BRANCH_NAME}"
    echo "params : $params"
-  
-   def build_job = env.API_BUILD_URI_DEV
+
+   def build_job = api_build_uri_dev
     if ( env.BRANCH_NAME == 'master') {
-      build_job = env.API_BUILD_URI
-    }  
+      build_job = api_build_uri
+    }
    def var_job_url = JenkinsLocationConfiguration.get().getUrl() + build_job
-  
+
     sh "curl -X GET -k -v -u \"$UNAME:$PWD\"  \"" + var_job_url + "&service_name={service_name}&domain={domain}&scm_branch=${env.BRANCH_NAME}\""
 }
-    
-  
+
+
+}
+
+/*
+* Load environment variables from build module
+*/
+def loadConfigModule(buildModuleUrl){
+	echo "loading env variables, checking repos..."
+
+	dir('config-loader') {
+		checkout([$class: 'GitSCM', branches: [
+			[name: '*/master']
+		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
+		]])
+
+		echo "loading installer variables..."
+
+		def resultJsonString = readFile("jazz-installer-vars.json")
+		configModule = load "config-loader.groovy"
+		configLoader = configModule.initialize(resultJsonString)
+		echo "finished loading env module"
+	}
 }

--- a/build-deploy-platform-services/Jenkinsfile
+++ b/build-deploy-platform-services/Jenkinsfile
@@ -52,7 +52,7 @@ node {
 
 	echo "params : $params"
 
-	loadConfigModule("http://${env.REPO_BASE}/scm/${env.REPO_CORE}/jazz-build-module.git")
+	loadConfigModule(params.config_module_url)
 	var_api_key 				= configLoader.API.API_KEY
 	var_api_id_dev = configLoader.API.API_ID_DEV
 	var_aws_credential_id = configLoader.AWS_CREDENTIAL_ID
@@ -377,7 +377,7 @@ node {
 					sh "aws lambda  create-event-source-mapping --event-source-arn arn:aws:kinesis:$region:$roleId:stream/" + var_env_name_prefix + "-events-hub-dev --function-name arn:aws:lambda:$region:$roleId:function:$function_name --starting-position LATEST --region " + region
 				}
 			}
-			
+
 
 			// @TODO : Resetting the credentials needs to be introduced. (Re-use of same profile on Async calls needs to be considered)
 			// resetCredentials();
@@ -509,7 +509,7 @@ def loadConfigModule(buildModuleUrl){
 		checkout([$class: 'GitSCM', branches: [
 			[name: '*/master']
 		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-			[credentialsId: env.REPO_CREDENTIAL_ID, url: buildModuleUrl]
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
 		]])
 
 		echo "loading installer variables..."

--- a/create-serverless-service/Jenkins
+++ b/create-serverless-service/Jenkins
@@ -38,7 +38,7 @@ def Event_Status = [
 ]
 
 node {
-	loadConfigModule("http://${env.REPO_BASE}/scm/${env.REPO_CORE}/jazz-build-module.git")
+	loadConfigModule(params.config_module_url)
 	var_credentialsId 			= configLoader.REPOSITORY.REPO_CREDENTIAL_ID
 	var_bitbucket_base			= configLoader.REPOSITORY.REPO_BASE
 	def var_bitbucket_framework_url = "http://" + var_bitbucket_base + "/scm/" + configLoader.REPOSITORY.REPO_CORE + "/"
@@ -288,7 +288,7 @@ def loadConfigModule(buildModuleUrl){
 		checkout([$class: 'GitSCM', branches: [
 			[name: '*/master']
 		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-			[credentialsId: env.REPO_CREDENTIAL_ID, url: buildModuleUrl]
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
 		]])
 
 		echo "loading installer variables..."

--- a/delete-serverless-service-build-pack/Jenkinsfile
+++ b/delete-serverless-service-build-pack/Jenkinsfile
@@ -34,7 +34,7 @@ node {
 	echo "Starting delete service job.."
 	echo "params : $params"
 
-	loadConfigModule("http://${env.REPO_BASE}/scm/${env.REPO_CORE}/jazz-build-module.git")
+	loadConfigModule(params.config_module_url)
 	region = configLoader.JAZZ.jazz_region
 	g_base_url = "https://${configLoader.API.API_KEY}.execute-api.${region}.amazonaws.com/dev"
 	role = configLoader.JAZZ.jazz_roleId
@@ -1172,7 +1172,7 @@ def loadConfigModule(buildModuleUrl){
 		checkout([$class: 'GitSCM', branches: [
 			[name: '*/master']
 		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-			[credentialsId: env.REPO_CREDENTIAL_ID, url: buildModuleUrl]
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
 		]])
 
 		echo "loading installer variables..."

--- a/delete-serverless-service-build-pack/Jenkinsfile_Cleanup_CF_Dist
+++ b/delete-serverless-service-build-pack/Jenkinsfile_Cleanup_CF_Dist
@@ -3,7 +3,12 @@ import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 import groovy.transform.Field
 
-//@Field def events
+import groovy.transform.Field
+
+@Field def configModule
+@Field def configLoader
+@Field def aws_credential_id
+@Field def env_name_prefix
 
 /**
  * The Jenkins Job deletes any diabled CloudFront Distributions
@@ -11,6 +16,10 @@ import groovy.transform.Field
 */
 
 node {
+
+	loadConfigModule(params.config_module_url)
+	aws_credential_id = configLoader.AWS_CREDENTIAL_ID
+	env_name_prefix = configLoader.env_name_prefix
 
 	echo "Starting delete Stack's Cloud Front Distributions that are disabled..."
 	echo "params : $params"
@@ -26,7 +35,7 @@ node {
  */
 def cleanupCloudFrontDistribution() {
 	withCredentials([
-		[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: env.AWS_CREDENTIAL_ID, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+		[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: aws_credential_id, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
 	]) {
 		try {
 			sh "aws configure set profile.cloud-api.region us-east-1"
@@ -35,11 +44,11 @@ def cleanupCloudFrontDistribution() {
 			sh "aws configure set preview.cloudfront true"
 
 			def eTag
-	
+
 			def idArray = getDisabledDistribution()
             if (idArray == null)
                return;
-			
+
             if (idArray.length > 0) {
                 for (indx = 0; indx < idArray.length; indx++) {
                   def distID = idArray[indx]
@@ -80,7 +89,7 @@ def getDisabledDistribution() {
 		outputStr = sh (
 			script: "aws cloudfront list-distributions \
 				--output json \
-				--query \"DistributionList.Items[].{Id: Id, Status: Status, Enabled: Enabled, OriginDomainName: Origins.Items[0].DomainName}[?!Enabled && contains(OriginDomainName, '$env.env_name_prefix-') && (Status == 'Deployed')]\"",
+				--query \"DistributionList.Items[].{Id: Id, Status: Status, Enabled: Enabled, OriginDomainName: Origins.Items[0].DomainName}[?!Enabled && contains(OriginDomainName, '$env_name_prefix-') && (Status == 'Deployed')]\"",
 			returnStdout: true
 		)
         if(outputStr) {
@@ -94,7 +103,7 @@ def getDisabledDistribution() {
             }
             return idArray
         }
-		
+
 		return null
 
 	}catch (ex) {
@@ -122,7 +131,7 @@ def getDistributionConfig(distributionID) {
 		echo "getDistributionConfig Failed."+ex.getMessage()
 		echo "getDistributionConfig Failed." + ex
         error "getDistributionConfig Failed."+ex.getMessage()
-        
+
 	}
 
 }
@@ -166,7 +175,7 @@ def generateDistributionConfigForDisable(distributionConfig) {
 def deleteCloudFrontDistribution(distributionID, eTag) {
 
     echo "deleteCloudFrontDistribution==$distributionID=====$eTag\r\n\r\n"
-     
+
 	def deleteOutput
 	try {
 		deleteOutput = sh(
@@ -180,4 +189,26 @@ def deleteCloudFrontDistribution(distributionID, eTag) {
 		error "deleteCloudFrontDistribution. "+e.getMessage()
 	}
 
+}
+
+/*
+* Load environment variables from build module
+*/
+def loadConfigModule(buildModuleUrl){
+	echo "loading env variables, checking repos..."
+
+	dir('config-loader') {
+		checkout([$class: 'GitSCM', branches: [
+			[name: '*/master']
+		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
+		]])
+
+		echo "loading installer variables..."
+
+		def resultJsonString = readFile("jazz-installer-vars.json")
+		configModule = load "config-loader.groovy"
+		configLoader = configModule.initialize(resultJsonString)
+		echo "finished loading env module"
+	}
 }

--- a/delete-serverless-service/Jenkinsfile
+++ b/delete-serverless-service/Jenkinsfile
@@ -39,7 +39,7 @@ def Event_Status = [
 
 node {
 
-	loadConfigModule("http://${env.REPO_BASE}/scm/${env.REPO_CORE}/jazz-build-module.git")
+	loadConfigModule(params.config_module_url)
 	var_credentialsId 			= configLoader.REPOSITORY.REPO_CREDENTIAL_ID
 	var_bitbucket_base			= configLoader.REPOSITORY.REPO_BASE
 	def var_bitbucket_framework_url = "http://" + var_bitbucket_base + "/scm/" + configLoader.REPOSITORY.REPO_CORE + "/"
@@ -289,7 +289,7 @@ def loadConfigModule(buildModuleUrl){
 		checkout([$class: 'GitSCM', branches: [
 			[name: '*/master']
 		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-			[credentialsId: env.REPO_CREDENTIAL_ID, url: buildModuleUrl]
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
 		]])
 
 		echo "loading installer variables..."

--- a/jenkins-build-pack-api/Jenkinsfile
+++ b/jenkins-build-pack-api/Jenkinsfile
@@ -63,7 +63,7 @@ def Event_Status = [
 @Field def aws_api_import = '/var/lib/aws-apigateway-importer/aws-api-import.sh'
 
 node() {
-	loadConfigModule("http://${env.REPO_BASE}/scm/${env.REPO_CORE}/jazz-build-module.git")
+	loadConfigModule(params.config_module_url)
 	var_api_key 				= configLoader.API.API_KEY
 	var_api_id_dev = configLoader.API.API_ID_DEV
 	var_aws_credential_id = configLoader.AWS_CREDENTIAL_ID
@@ -995,7 +995,7 @@ def loadConfigModule(buildModuleUrl){
 		checkout([$class: 'GitSCM', branches: [
 			[name: '*/master']
 		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-			[credentialsId: env.REPO_CREDENTIAL_ID, url: buildModuleUrl]
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
 		]])
 
 		echo "loading installer variables..."

--- a/jenkins-build-pack-lambda/Jenkinsfile
+++ b/jenkins-build-pack-lambda/Jenkinsfile
@@ -68,7 +68,7 @@ def Event_Status = [
 @Field def jq = '/usr/local/bin/jq'
 
 node ()  {
-	loadConfigModule("http://${env.REPO_BASE}/scm/${env.REPO_CORE}/jazz-build-module.git")
+	loadConfigModule(params.config_module_url)
 	var_api_key 				= configLoader.API.API_KEY
 	var_api_id_dev = configLoader.API.API_ID_DEV
 	var_aws_credential_id = configLoader.AWS_CREDENTIAL_ID
@@ -841,7 +841,7 @@ def loadConfigModule(buildModuleUrl){
 		checkout([$class: 'GitSCM', branches: [
 			[name: '*/master']
 		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-			[credentialsId: env.REPO_CREDENTIAL_ID, url: buildModuleUrl]
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
 		]])
 
 		echo "loading installer variables..."

--- a/jenkins-build-pack-website/Jenkinsfile
+++ b/jenkins-build-pack-website/Jenkinsfile
@@ -57,7 +57,7 @@ def Event_Status = [
 @Field def jq = '/usr/local/bin/jq'
 
 node ()  {
-	loadConfigModule("http://${env.REPO_BASE}/scm/${env.REPO_CORE}/jazz-build-module.git")
+	loadConfigModule(params.config_module_url)
 	var_api_key 				= configLoader.API.API_KEY
 	var_api_id_dev = configLoader.API.API_ID_DEV
 	var_aws_credential_id = configLoader.AWS_CREDENTIAL_ID
@@ -898,7 +898,7 @@ def loadConfigModule(buildModuleUrl){
 		checkout([$class: 'GitSCM', branches: [
 			[name: '*/master']
 		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-			[credentialsId: env.REPO_CREDENTIAL_ID, url: buildModuleUrl]
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
 		]])
 
 		echo "loading installer variables..."

--- a/lambda-template-java/Jenkinsfile
+++ b/lambda-template-java/Jenkinsfile
@@ -1,21 +1,57 @@
 #!groovy
 import groovy.json.JsonOutput
+import groovy.transform.Field
+
+@Field def configModule
+@Field def configLoader
+@Field def jenkins_credential_id
+@Field def lambda_build_uri_dev
+@Field def lambda_build_uri
+
 node {
 
-withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.JENKINS_CREDENTIAL_ID, passwordVariable: 'PWD', 
+loadConfigModule(params.config_module_url)
+jenkins_credential_id = configLoader.JENKINS.JENKINS_CREDENTIAL_ID
+lambda_build_uri = configLoader.LAMBDA.LAMBDA_BUILD_URI
+lambda_build_uri_dev = configLoader.LAMBDA.LAMBDA_BUILD_URI_DEV
+
+
+withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: jenkins_credential_id, passwordVariable: 'PWD',
 usernameVariable: 'UNAME']]){
-    
+
    echo "Build triggered via branch::${env.BRANCH_NAME}"
    echo "params : $params"
-  
-   def build_job = env.LAMBDA_BUILD_URI_DEV
+
+   def build_job = lambda_build_uri_dev
     if ( env.BRANCH_NAME == 'master') {
-      build_job = env.LAMBDA_BUILD_URI
-    }  
+      build_job = lambda_build_uri
+    }
    def var_job_url = JenkinsLocationConfiguration.get().getUrl() + build_job
-  
+
     sh "curl -X GET -k -v -u \"$UNAME:$PWD\"  \"" + var_job_url + "&service_name={service_name}&domain={domain}&scm_branch=${env.BRANCH_NAME}\""
 }
-    
-  
+
+
+}
+
+/*
+* Load environment variables from build module
+*/
+def loadConfigModule(buildModuleUrl){
+	echo "loading env variables, checking repos..."
+
+	dir('config-loader') {
+		checkout([$class: 'GitSCM', branches: [
+			[name: '*/master']
+		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
+		]])
+
+		echo "loading installer variables..."
+
+		def resultJsonString = readFile("jazz-installer-vars.json")
+		configModule = load "config-loader.groovy"
+		configLoader = configModule.initialize(resultJsonString)
+		echo "finished loading env module"
+	}
 }

--- a/lambda-template-python/Jenkinsfile
+++ b/lambda-template-python/Jenkinsfile
@@ -1,21 +1,55 @@
 #!groovy
 import groovy.json.JsonOutput
+import groovy.transform.Field
+
+@Field def configModule
+@Field def configLoader
+@Field def jenkins_credential_id
+@Field def lambda_build_uri_dev
+@Field def lambda_build_uri
+
 node {
 
-withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.JENKINS_CREDENTIAL_ID, passwordVariable: 'PWD', 
+loadConfigModule(params.config_module_url)
+jenkins_credential_id = configLoader.JENKINS.JENKINS_CREDENTIAL_ID
+lambda_build_uri = configLoader.LAMBDA.LAMBDA_BUILD_URI
+lambda_build_uri_dev = configLoader.LAMBDA.LAMBDA_BUILD_URI_DEV
+
+withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: jenkins_credential_id, passwordVariable: 'PWD',
 usernameVariable: 'UNAME']]){
-    
+
    echo "Build triggered via branch::${env.BRANCH_NAME}"
    echo "params : $params"
-  
-   def build_job = env.LAMBDA_BUILD_URI_DEV
+
+   def build_job = lambda_build_uri_dev
     if ( env.BRANCH_NAME == 'master') {
-      build_job = env.LAMBDA_BUILD_URI
-    }  
+      build_job = lambda_build_uri
+    }
    def var_job_url = JenkinsLocationConfiguration.get().getUrl() + build_job
-  
+
     sh "curl -X GET -k -v -u \"$UNAME:$PWD\"  \"" + var_job_url + "&service_name={service_name}&domain={domain}&scm_branch=${env.BRANCH_NAME}\""
 }
-    
-  
+
+}
+
+/*
+* Load environment variables from build module
+*/
+def loadConfigModule(buildModuleUrl){
+	echo "loading env variables, checking repos..."
+
+	dir('config-loader') {
+		checkout([$class: 'GitSCM', branches: [
+			[name: '*/master']
+		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
+		]])
+
+		echo "loading installer variables..."
+
+		def resultJsonString = readFile("jazz-installer-vars.json")
+		configModule = load "config-loader.groovy"
+		configLoader = configModule.initialize(resultJsonString)
+		echo "finished loading env module"
+	}
 }

--- a/platform_email/Jenkinsfile_Platform
+++ b/platform_email/Jenkinsfile_Platform
@@ -1,24 +1,54 @@
 #!groovy
 import groovy.json.JsonOutput
+import groovy.transform.Field
+
+@Field def configModule
+@Field def configLoader
+@Field def jenkins_credential_id
+
 node {
 
-withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.JENKINS_CREDENTIAL_ID, passwordVariable: 'PWD', 
+loadConfigModule(params.config_module_url)
+jenkins_credential_id = configLoader.JENKINS.JENKINS_CREDENTIAL_ID
+
+withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: jenkins_credential_id, passwordVariable: 'PWD', 
 usernameVariable: 'UNAME']]){
-    
+
    echo "Build triggered via branch::${env.BRANCH_NAME}"
    echo "Build triggered for JOBNAME::" + env.JOB_NAME
 
    def projname = env.JOB_NAME
    projname = projname.replaceAll('slf/', '')
    projname = projname.replaceAll('/' + env.BRANCH_NAME, '')
-   
+
    echo "projname::" + projname
-   
+
    def build_job = '/job/build-deploy-platform-service/buildWithParameters?token=bld-plat-srvs-71717'
    def var_job_url = JenkinsLocationConfiguration.get().getUrl() + build_job
-  
+
    sh "curl -X GET -k -v -u \"$UNAME:$PWD\"  \"" + var_job_url + "&service_name=" + projname + "&admin_group=admin_group&region=us-east-1&deploy_env=dev\""
 }
-    
-  
+
+}
+
+/*
+* Load environment variables from build module
+*/
+def loadConfigModule(buildModuleUrl){
+	echo "loading env variables, checking repos..."
+
+	dir('config-loader') {
+		checkout([$class: 'GitSCM', branches: [
+			[name: '*/master']
+		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
+		]])
+
+		echo "loading installer variables..."
+
+		def resultJsonString = readFile("jazz-installer-vars.json")
+		configModule = load "config-loader.groovy"
+		configLoader = configModule.initialize(resultJsonString)
+		echo "finished loading env module"
+	}
 }

--- a/platform_logs/Jenkinsfile_Platform
+++ b/platform_logs/Jenkinsfile_Platform
@@ -1,24 +1,54 @@
 #!groovy
 import groovy.json.JsonOutput
+import groovy.transform.Field
+
+@Field def configModule
+@Field def configLoader
+@Field def jenkins_credential_id
+
 node {
 
-withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.JENKINS_CREDENTIAL_ID, passwordVariable: 'PWD', 
+loadConfigModule(params.config_module_url)
+jenkins_credential_id = configLoader.JENKINS.JENKINS_CREDENTIAL_ID
+
+withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: jenkins_credential_id, passwordVariable: 'PWD', 
 usernameVariable: 'UNAME']]){
-    
+
    echo "Build triggered via branch::${env.BRANCH_NAME}"
    echo "Build triggered for JOBNAME::" + env.JOB_NAME
 
    def projname = env.JOB_NAME
    projname = projname.replaceAll('slf/', '')
    projname = projname.replaceAll('/' + env.BRANCH_NAME, '')
-   
+
    echo "projname::" + projname
-   
+
    def build_job = '/job/build-deploy-platform-service/buildWithParameters?token=bld-plat-srvs-71717'
    def var_job_url = JenkinsLocationConfiguration.get().getUrl() + build_job
-  
+
    sh "curl -X GET -k -v -u \"$UNAME:$PWD\"  \"" + var_job_url + "&service_name=" + projname + "&admin_group=admin_group&region=us-east-1&deploy_env=dev\""
 }
-    
-  
+
+}
+
+/*
+* Load environment variables from build module
+*/
+def loadConfigModule(buildModuleUrl){
+	echo "loading env variables, checking repos..."
+
+	dir('config-loader') {
+		checkout([$class: 'GitSCM', branches: [
+			[name: '*/master']
+		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
+		]])
+
+		echo "loading installer variables..."
+
+		def resultJsonString = readFile("jazz-installer-vars.json")
+		configModule = load "config-loader.groovy"
+		configLoader = configModule.initialize(resultJsonString)
+		echo "finished loading env module"
+	}
 }

--- a/platform_usermanagement/Jenkinsfile_Platform
+++ b/platform_usermanagement/Jenkinsfile_Platform
@@ -1,24 +1,54 @@
 #!groovy
 import groovy.json.JsonOutput
+import groovy.transform.Field
+
+@Field def configModule
+@Field def configLoader
+@Field def jenkins_credential_id
+
 node {
 
-withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.JENKINS_CREDENTIAL_ID, passwordVariable: 'PWD', 
+loadConfigModule(params.config_module_url)
+jenkins_credential_id = configLoader.JENKINS.JENKINS_CREDENTIAL_ID
+
+withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: jenkins_credential_id, passwordVariable: 'PWD', 
 usernameVariable: 'UNAME']]){
-    
+
    echo "Build triggered via branch::${env.BRANCH_NAME}"
    echo "Build triggered for JOBNAME::" + env.JOB_NAME
 
    def projname = env.JOB_NAME
    projname = projname.replaceAll('slf/', '')
    projname = projname.replaceAll('/' + env.BRANCH_NAME, '')
-   
+
    echo "projname::" + projname
-   
+
    def build_job = '/job/build-deploy-platform-service/buildWithParameters?token=bld-plat-srvs-71717'
    def var_job_url = JenkinsLocationConfiguration.get().getUrl() + build_job
-  
+
    sh "curl -X GET -k -v -u \"$UNAME:$PWD\"  \"" + var_job_url + "&service_name=" + projname + "&admin_group=admin_group&region=us-east-1&deploy_env=dev\""
 }
-    
-  
+
+}
+
+/*
+* Load environment variables from build module
+*/
+def loadConfigModule(buildModuleUrl){
+	echo "loading env variables, checking repos..."
+
+	dir('config-loader') {
+		checkout([$class: 'GitSCM', branches: [
+			[name: '*/master']
+		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
+		]])
+
+		echo "loading installer variables..."
+
+		def resultJsonString = readFile("jazz-installer-vars.json")
+		configModule = load "config-loader.groovy"
+		configLoader = configModule.initialize(resultJsonString)
+		echo "finished loading env module"
+	}
 }

--- a/service-onboarding-build-pack/Jenkinsfile
+++ b/service-onboarding-build-pack/Jenkinsfile
@@ -44,7 +44,7 @@ def Event_Status = [
 @Field def region = ''
 
 node  {
-	loadConfigModule("http://${env.REPO_BASE}/scm/${env.REPO_CORE}/jazz-build-module.git")
+	loadConfigModule(params.config_module_url)
 	region = configLoader.JAZZ.jazz_region
 	g_base_url = "https://${configLoader.API.API_KEY}.execute-api.${region}.amazonaws.com/dev"
 	role = configLoader.JAZZ.jazz_roleId
@@ -604,7 +604,7 @@ def loadConfigModule(buildModuleUrl){
 		checkout([$class: 'GitSCM', branches: [
 			[name: '*/master']
 		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-			[credentialsId: env.REPO_CREDENTIAL_ID, url: buildModuleUrl]
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
 		]])
 
 		echo "loading installer variables..."

--- a/static-website-template/Jenkinsfile
+++ b/static-website-template/Jenkinsfile
@@ -1,20 +1,55 @@
 #!groovy
 import groovy.json.JsonOutput
+import groovy.transform.Field
+
+@Field def configModule
+@Field def configLoader
+@Field def jenkins_credential_id
+@Field def website_build_uri_dev
+@Field def website_build_uri
+
 node {
 
-	withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.JENKINS_CREDENTIAL_ID, passwordVariable: 'PWD', 
+	loadConfigModule(params.config_module_url)
+	jenkins_credential_id = configLoader.JENKINS.JENKINS_CREDENTIAL_ID
+	website_build_uri = configLoader.WEBSITE.WEBSITE_BUILD_URI
+	website_build_uri_dev = configLoader.WEBSITE.WEBSITE_BUILD_URI_DEV
+
+	withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: jenkins_credential_id, passwordVariable: 'PWD',
 	usernameVariable: 'UNAME']]){
-		
+
 	   echo "Build triggered via branch::${env.BRANCH_NAME}"
 	   echo "params : $params"
-	  
-	   def build_job = env.WEBSITE_BUILD_URI_DEV
+
+	   def build_job = website_build_uri_dev
 		if ( env.BRANCH_NAME == 'master') {
-		  build_job = env.WEBSITE_BUILD_URI
-		}  
+		  build_job = website_build_uri
+		}
 	   def var_job_url = JenkinsLocationConfiguration.get().getUrl() + build_job
-	  
+
 		sh "curl -X GET -k -v -u \"$UNAME:$PWD\"  \"" + var_job_url + "&service_name={service_name}&domain={domain}&scm_project=cas&scm_branch=${env.BRANCH_NAME}\""
 	}
 
+}
+
+/*
+* Load environment variables from build module
+*/
+def loadConfigModule(buildModuleUrl){
+	echo "loading env variables, checking repos..."
+
+	dir('config-loader') {
+		checkout([$class: 'GitSCM', branches: [
+			[name: '*/master']
+		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
+			[credentialsId: params.config_module_credential_id, url: buildModuleUrl]
+		]])
+
+		echo "loading installer variables..."
+
+		def resultJsonString = readFile("jazz-installer-vars.json")
+		configModule = load "config-loader.groovy"
+		configLoader = configModule.initialize(resultJsonString)
+		echo "finished loading env module"
+	}
 }


### PR DESCRIPTION
### Requirements

Remove excess env.vars from all the jenkins builds and have them be implemented as params values where applicable.

### Description of the Change

Added in configLoader integration logic for all jenkinsFiles and passed in future params values as input values. 

### Possible Drawbacks

Integration with the installer has to be made

### Applicable Issues
The jazz installer project has yet to set these values, builds will fail unless updated on the installer side.
