### PR TITLE
v.1.4: Gitlabs install for user services enforcing no commits to master

### DIFF
--- a/service-onboarding-build-pack/Jenkinsfile
+++ b/service-onboarding-build-pack/Jenkinsfile
@@ -431,6 +431,13 @@ node  {
 						echo error
 					}
 				}
+                
+                if(scm == "gitlab"){
+                    //Making the gitlab master branch commit protected.
+                    def var_private_token = env.gitlab_private_token
+                    sh "curl --request DELETE --header \"PRIVATE-TOKEN: $var_private_token\" \"http://$repo_base/api/v3/projects/$cas_proj_id/protected_branches/master\""
+                    sh "curl --request POST --header \"PRIVATE-TOKEN: $var_private_token\" \"http://$repo_base/api/v3/projects/$cas_proj_id/protected_branches?name=master&push_access_level=0\""
+                }
 
 				echo "Calling update row in db ###################################################"
 				updateServiceInDB(service_id_in_db, env.API_KEY, region, "creation_completed", repo_url);


### PR DESCRIPTION
### Requirements

Currently in Gitlab the master batch is accepting commits . This change is to enforcing no commits to master.

### Description of the Change

Currently in Gitlab the master batch is accepting commits. This change is to enforcing no commits to master.

### Benefits

With this changes only user commits can come only through PR's

### Possible Drawbacks



### Applicable Issues


