### PR TITLE
CAPI-1210 : Add platform services to catalog during installation

### DIFF
--- a/build-deploy-platform-services/Jenkinsfile
+++ b/build-deploy-platform-services/Jenkinsfile
@@ -142,7 +142,6 @@ node {
 	}
 
 	def config = loadServiceMetadata(serviceObj.service_id,region)
-	echo "sini"
 	def roleARN						= config['iamRoleARN'].replaceAll("/", "\\\\/")
     service_name					= config['service']
 

--- a/build-deploy-platform-services/Jenkinsfile
+++ b/build-deploy-platform-services/Jenkinsfile
@@ -473,17 +473,13 @@ def loadServiceMetadata(service_id, region){
 	
 	withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID',
 		credentialsId: configLoader.AWS_CREDENTIAL_ID, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-		// sh "aws configure set profile.cloud-api.region " + region
-		// sh "aws configure set profile.cloud-api.aws_access_key_id $AWS_ACCESS_KEY_ID"
-		// sh "aws configure set profile.cloud-api.aws_secret_access_key $AWS_SECRET_ACCESS_KEY"
-		
+			
 		def table_name = var_env_name_prefix + "_services_prod"
 		def service_Object = sh (
 				script: "aws --region $region dynamodb get-item --table-name $table_name --key '{\"SERVICE_ID\": {\"S\":\"$service_id\"}}' --output json" ,
 				returnStdout: true
 			).trim()
 		
-		echo "service_Object : $service_Object" 
 		
 		if(service_Object){
 			def service_data = parseJson(service_Object)
@@ -491,11 +487,8 @@ def loadServiceMetadata(service_id, region){
 			def metadata = [:]
 			
 			for(item in data){
-				echo "$item.key : $item.value.S" 
 				metadata[item.key] = item.value.S				
-			}
-			echo "metadata : $metadata" 
-			
+			}			
 			return metadata
 		}
 	}

--- a/build-deploy-platform-services/Jenkinsfile
+++ b/build-deploy-platform-services/Jenkinsfile
@@ -1,11 +1,12 @@
 #!groovy
 import groovy.json.JsonOutput
 import groovy.transform.Field
+import groovy.json.JsonSlurperClassic
 
 // To be replaced as @Field def repo_credential_id = "value" for repo_credential_id, repo_base and repo_core
-@Field def repo_credential_id
-@Field def repo_base
-@Field def repo_core
+@Field def repo_credential_id = "jenkins1cred"
+@Field def repo_base = "jazz-daily-installer-bitbucket-1723618883.us-east-1.elb.amazonaws.com"
+@Field def repo_core = "slf"
 @Field def configModule
 @Field def configLoader
 @Field def var_api_key
@@ -135,11 +136,13 @@ node {
 	}
 
 	// Need to be refactored
-	def config = dir(bitbucket_name)
+	def serviceObj = dir(bitbucket_name)
 	{
 	    return LoadConfiguration()
 	}
 
+	def config = loadServiceMetadata(serviceObj.service_id,region)
+	echo "sini"
 	def roleARN						= config['iamRoleARN'].replaceAll("/", "\\\\/")
     service_name					= config['service']
 
@@ -206,6 +209,8 @@ node {
 			//Change lambda service name to add stack prefix name
 			sh "sed -i -- 's/" + service_name + "/" + var_env_name_prefix + "-" + service_name + "/g' ./deployment-env.yml"
 
+			writeServerlessFile(config)
+			
 			echo "Deploying lambda service"
 
 			def envBucketKey = configLoader.JAZZ_S3.jazz_bucket_name_prefix + envmnt
@@ -274,6 +279,29 @@ def generateSwaggerEnv(service, env, deploymentNode, apiHostName, domain, servic
     sh "sed -i -- 's/{domain}/" + domain + "/g' swagger/swagger.json" // {domain}
     sh "sed -i -- 's/{envPrefix}/" + env_name_prefix + "/g' swagger/swagger.json" // {domain}
 	sh "sed -i -- 's/{envmnt}/" + env + "/g' swagger/swagger.json" // {environment}
+}
+
+def writeServerlessFile(config){
+	sh "sed -i -- 's/\${file(deployment-env.yml):service}/" + config['service'] + "/g' serverless.yml"
+	sh "sed -i -- 's/\${file(deployment-env.yml):region}/" + config['region'] + "/g' serverless.yml"
+	sh "sed -i -- 's/\${file(deployment-env.yml):domain, self:provider.domain}/" + config['domain'] + "/g' serverless.yml"
+	sh "sed -i -- 's/\${file(deployment-env.yml):owner, self:provider.owner}/" + config['owner'] + "/g' serverless.yml"
+	sh "sed -i -e 's|\${file(deployment-env.yml):iamRoleARN}|" + config['iamRoleARN'] + "|g' serverless.yml" 	
+	sh "sed -i -- 's/\${file(deployment-env.yml):providerRuntime}/" + config['providerRuntime'] + "/g' serverless.yml"
+	sh "sed -i -- 's/\${file(deployment-env.yml):providerMemorySize}/" + config['providerMemorySize'] + "/g' serverless.yml"
+	sh "sed -i -- 's/\${file(deployment-env.yml):providerTimeout}/" + config['providerTimeout'] + "/g' serverless.yml"
+	sh "sed -i -- 's/\${file(deployment-env.yml):eventScheduleRate}/" + config['eventScheduleRate'] + "/g' serverless.yml"
+	sh "sed -i -- 's/\${file(deployment-env.yml):eventScheduleEnable}/" + config['eventScheduleEnable'] + "/g' serverless.yml"
+	sh "sed -i -- 's/\${file(deployment-env.yml):securityGroupIds}/" + config['securityGroupIds'] + "/g' serverless.yml"
+	sh "sed -i -- 's/\${file(deployment-env.yml):subnetIds}/" + config['subnetIds'] + "/g' serverless.yml"
+	
+	if(config['artifact']){
+		sh "sed -i -- 's/\${file(deployment-env.yml):artifact}/" + config['artifact'] + "/g' serverless.yml"
+	}
+	if(config['mainClass']){
+		sh "sed -i -- 's/\${file(deployment-env.yml):mainClass}/" + config['mainClass'] + "/g' serverless.yml"
+	}
+	
 }
 
 /**
@@ -432,4 +460,44 @@ def loadServiceConfigurationDataModule(buildURL,configLoader,role_arn, region, r
 		}catch(ex) {
 			error "loadServiceConfigurationDataModule Failed. "+ex.getMessage()
 		}
+}
+
+@NonCPS
+def parseJson(jsonString) {
+    def lazyMap = new groovy.json.JsonSlurperClassic().parseText(jsonString)
+    def m = [:]
+    m.putAll(lazyMap)
+    return m
+}
+
+def loadServiceMetadata(service_id, region){
+	
+	withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+		credentialsId: configLoader.AWS_CREDENTIAL_ID, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+		// sh "aws configure set profile.cloud-api.region " + region
+		// sh "aws configure set profile.cloud-api.aws_access_key_id $AWS_ACCESS_KEY_ID"
+		// sh "aws configure set profile.cloud-api.aws_secret_access_key $AWS_SECRET_ACCESS_KEY"
+		
+		def table_name = var_env_name_prefix + "_services_prod"
+		def service_Object = sh (
+				script: "aws --region $region dynamodb get-item --table-name $table_name --key '{\"SERVICE_ID\": {\"S\":\"$service_id\"}}' --output json" ,
+				returnStdout: true
+			).trim()
+		
+		echo "service_Object : $service_Object" 
+		
+		if(service_Object){
+			def service_data = parseJson(service_Object)
+			def data = service_data.Item.SERVICE_METADATA.M
+			def metadata = [:]
+			
+			for(item in data){
+				echo "$item.key : $item.value.S" 
+				metadata[item.key] = item.value.S				
+			}
+			echo "metadata : $metadata" 
+			
+			return metadata
+		}
+	}
 }

--- a/build-deploy-platform-services/Jenkinsfile
+++ b/build-deploy-platform-services/Jenkinsfile
@@ -4,9 +4,9 @@ import groovy.transform.Field
 import groovy.json.JsonSlurperClassic
 
 // To be replaced as @Field def repo_credential_id = "value" for repo_credential_id, repo_base and repo_core
-@Field def repo_credential_id = "jenkins1cred"
-@Field def repo_base = "jazz-daily-installer-bitbucket-1723618883.us-east-1.elb.amazonaws.com"
-@Field def repo_core = "slf"
+@Field def repo_credential_id
+@Field def repo_base
+@Field def repo_core
 @Field def configModule
 @Field def configLoader
 @Field def var_api_key


### PR DESCRIPTION
### Requirements

CAPI-1210 : Add platform services to catalog during installation

### Description of the Change

1. Generate a service id and update all platform services with that.
2. Bootstrap job/script that will hold all the meta-data for the service id from step (1) and add it as a post-install step to dynamodb.

### Benefits

1. platform services use new structure
2. Service deployment workflows continue to work

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
