### PR TITLE
CAPI-1210 : Add platform services to catalog during installation

### DIFF
--- a/build-deploy-platform-services/Jenkinsfile
+++ b/build-deploy-platform-services/Jenkinsfile
@@ -233,7 +233,7 @@ node {
 				try {
 					def rd = sh(script: "openssl rand -hex 4", returnStdout:true).trim()
 
-					 sh "aws lambda add-permission --function-name arn:aws:lambda:" + region + ":" + roleId + ":function:" + var_env_name_prefix + "-cloud-logs-streamer-" + envmnt + " --statement-id lambdaFxnPermission${rd} --action lambda:* --principal logs." + region + ".amazonaws.com --region " + region
+					 sh "aws lambda add-permission --function-name arn:aws:lambda:" + region + ":" + roleId + ":function:" + var_env_name_prefix  + "-" + config['service'] + "-" +  envmnt + " --statement-id lambdaFxnPermission${rd} --action lambda:* --principal logs." + region + ".amazonaws.com --region " + region
 					 echo "set permission for cloud-logs-streamer - success"
 				 }catch(ss) {
 					//ignore if already registered permissions
@@ -243,7 +243,7 @@ node {
 			}
 
 			if ( (service_template.trim() == "platform-services-handler") ) {
-				def function_name =  var_env_name_prefix + "-hndlr-"+ envmnt
+				def function_name =  var_env_name_prefix  + "-" + config['service'] + "-" +  envmnt
 				def event_source_list = sh (
 					script: "aws lambda list-event-source-mappings --query \"EventSourceMappings[?contains(FunctionArn, '$function_name')]\" --region \"$region\"" ,
 					returnStdout: true

--- a/build-deploy-platform-services/Jenkinsfile
+++ b/build-deploy-platform-services/Jenkinsfile
@@ -205,9 +205,6 @@ node {
 			sh "npm install --save"
 			echo "NPM Build completed"
 
-			//Change lambda service name to add stack prefix name
-			sh "sed -i -- 's/" + service_name + "/" + var_env_name_prefix + "-" + service_name + "/g' ./deployment-env.yml"
-
 			writeServerlessFile(config)
 			
 			echo "Deploying lambda service"
@@ -281,7 +278,7 @@ def generateSwaggerEnv(service, env, deploymentNode, apiHostName, domain, servic
 }
 
 def writeServerlessFile(config){
-	sh "sed -i -- 's/\${file(deployment-env.yml):service}/" + config['service'] + "/g' serverless.yml"
+	sh "sed -i -- 's/\${file(deployment-env.yml):service}/${configLoader.env_name_prefix}-${config['service']}/g' serverless.yml"
 	sh "sed -i -- 's/\${file(deployment-env.yml):region}/" + config['region'] + "/g' serverless.yml"
 	sh "sed -i -- 's/\${file(deployment-env.yml):domain, self:provider.domain}/" + config['domain'] + "/g' serverless.yml"
 	sh "sed -i -- 's/\${file(deployment-env.yml):owner, self:provider.owner}/" + config['owner'] + "/g' serverless.yml"
@@ -488,7 +485,12 @@ def loadServiceMetadata(service_id, region){
 			
 			for(item in data){
 				metadata[item.key] = item.value.S				
-			}			
+			}
+			metadata['service'] = service_data.Item.SERVICE_NAME.S
+			metadata['domain'] = service_data.Item.SERVICE_DOMAIN.S
+			metadata['owner'] = service_data.Item.SERVICE_CREATED_BY.S
+			metadata['region'] = region
+			
 			return metadata
 		}
 	}


### PR DESCRIPTION
### Requirements

CAPI-1210 : Add platform services to catalog during installation

### Description of the Change
1. Generate a service id and update all platform services with that.
2. Bootstrap job/script that will hold all the meta-data for the service id from step (1) and add it as a post-install step to dynamodb.

### Benefits

1. platform services use new structure
2. Service deployment workflows continue to work

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
