### PR TITLE
Increase password length to 8 characters

### DIFF
--- a/jazz-ui/src/app/pages/login/login.component.html
+++ b/jazz-ui/src/app/pages/login/login.component.html
@@ -34,9 +34,9 @@
                 
                 <div class="form-row bottom-2" *ngIf="!forgot_password || register || new_pwd_req">
                         <div class="form-label">Password </div>
-                        <input required minlength="6" [class.err-border]='err_password_brd || (model.password && (!password.valid && (password.dirty || password.touched))) && (register || new_pwd_req)' type="password" name='password' [(ngModel)]="model.password"  (ngModelChange)="onChange($event)" #password='ngModel'>
+                        <input required minlength="8" [class.err-border]='err_password_brd || (model.password && (!password.valid && (password.dirty || password.touched))) && (register || new_pwd_req)' type="password" name='password' [(ngModel)]="model.password"  (ngModelChange)="onChange($event)" #password='ngModel'>
                         <ul class='login-form-errmsg' *ngIf="model.password && (!password.valid && (password.dirty || password.touched)) && (register || new_pwd_req)">
-                            Password must be atleast 6 characters long
+                            Password must be atleast 8 characters long
                         </ul>
                         <div *ngIf="!register" class='hide-er' [class.error-msg]="error_password_disp">
                                 <div>


### PR DESCRIPTION
### Description of the Change

Increase password length to 8 characters (LCD of gitlabs and bitbucket)

### Benefits

Registration of users whether with Gitlabs or Bitbucket works seamlessly

### Possible Drawbacks
Existing bitbucket installs might see an unexpected change
