### PR TITLE
Dynamic AWS API Ids

### DIFF
--- a/delete-serverless-service-build-pack/Jenkinsfile
+++ b/delete-serverless-service-build-pack/Jenkinsfile
@@ -898,9 +898,8 @@ def loadServerlessConfig(String runtime) {
 }
 
 def updateServiceInDB(service_id_in_db, statusval) {
-	def apiId = utilModule.getAPIIdForCore(configLoader.AWS.API["PROD"])
-  	sh "curl -H \"Content-Type: application/json\"  -H \"Authorization: "+auth_token+"\" -X PUT -k -v -d \
-  		'{ \"status\": \"${statusval}\"}' https://${apiId}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod/jazz/services/${service_id_in_db}?isAdmin=true"
+	sh "curl -H \"Content-Type: application/json\"  -H \"Authorization: "+auth_token+"\" -X PUT -k -v -d \
+  		'{ \"status\": \"${statusval}\"}' ${g_base_url}/jazz/services/${service_id_in_db}?isAdmin=true"
 }
 
 
@@ -912,7 +911,7 @@ def loadEventsModule() {
 
 def loadServiceInfo() {
 	def token = setCredentials()
-	def url = "$g_base_url/jazz/services?domain=$domain&service=$service&isAdmin=true"
+	def url = "${g_base_url}/jazz/services?domain=$domain&service=$service&isAdmin=true"
 
 	def curlOutput = sh (script: "curl -H \"Content-Type: application/json\" \
 			-H \"Authorization: $token\" \"$url\"" ,returnStdout: true ).trim()

--- a/delete-serverless-service-build-pack/Jenkinsfile
+++ b/delete-serverless-service-build-pack/Jenkinsfile
@@ -15,8 +15,8 @@ import groovy.transform.Field
 @Field def configModule
 @Field def configLoader
 @Field def scmModule
+@Field def utilModule
 
-@Field def Util
 @Field def serviceMetadata
 @Field def g_base_url = ''
 @Field def g_svc_admin_cred_ID = 'SVC_ADMIN'
@@ -31,10 +31,12 @@ node {
 	echo "Starting delete service job with params : $params"
 
 	jazzBuildModuleURL = getBuildModuleUrl()
-	loadConfigModule(jazzBuildModuleURL)
-	loadSCMModule(jazzBuildModuleURL)
+	loadBuildModules(jazzBuildModuleURL)
 
-	g_base_url = "https://${configLoader.AWS.API.PROD_ID}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod"
+	def jazz_prod_api_id = utilModule.getAPIIdForCore(configLoader.AWS.API["PROD"])
+
+	g_base_url = "https://${jazz_prod_api_id}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod"
+
 	role = configLoader.AWS.ROLEID
 	
 	def service_name
@@ -98,7 +100,7 @@ node {
 		runtime = config['providerRuntime']
 		serviceConfig = config['service']
 		domainConfig = config['domain']
-		updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_started");
+		updateServiceInDB(var_db_service_id, "deletion_started");
 		dir(repo_name){
 			echo "loadServerlessConfig......."
 
@@ -214,7 +216,7 @@ def unDeployService(stage, region) {
 			echo "Service undeployed"
 			//events.sendCompletedEvent('UNDEPLOY_LAMBDA', null, null, getEnvKey(stage))
 		}catch(ex) {
-			updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, region, "deletion_failed");
+			updateServiceInDB(var_db_service_id, "deletion_failed");
 			//events.sendFailureEvent('UNDEPLOY_LAMBDA', ex.getMessage(), null, getEnvKey(stage))
 			send_status_email ("FAILED")
 			error ex.getMessage()
@@ -239,7 +241,7 @@ def checkoutSCM(repo_name) {
 				[credentialsId: configLoader.REPOSITORY.CREDENTIAL_ID, url: repo_url]
 			]])
 		}catch(ex) {
-			updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_failed");
+			updateServiceInDB(var_db_service_id, "deletion_failed");
 			send_status_email ("FAILED")
 			error "checkoutSCM Failed. "+ex.getMessage()
 		}
@@ -260,7 +262,7 @@ def updateServiceNameConfig(envval,config) {
 		sh "sed -i -- 's/name: \${self:service}/name: ${configLoader.INSTANCE_PREFIX}-${config['domain']}-${config['service']}/g' serverless.yml"
 		writeServerlessFile(config)
 	}catch(ex) {
-		updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_failed");
+		updateServiceInDB(var_db_service_id, "deletion_failed");
 		send_status_email ("FAILED")
 		error "updateServiceNameConfig Failed. "+ex.getMessage()
 	}
@@ -313,7 +315,7 @@ def updateSwaggerConfig(domain, serviceName, api_key, config) {
 		}
 		//events.sendCompletedEvent('UPDATE_SWAGGER')
 	}catch(ex) {
-		updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_failed");
+		updateServiceInDB(var_db_service_id, "deletion_failed");
 		send_status_email ("FAILED")
 		error "updateServiceNameConfig Failed. "+ex.getMessage()
 	}
@@ -348,7 +350,7 @@ def LoadConfiguration() {
 		//events.sendCompletedEvent('GET_DEPLOYMENT_CONF')
 		return prop
 	}catch(ex) {
-		updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_failed");
+		updateServiceInDB(var_db_service_id, "deletion_failed");
 		send_status_email ("FAILED")
 		error "LoadConfiguration Failed. "+ex.getMessage()
 	}
@@ -394,7 +396,7 @@ def checkServiceExists(service_name, domain, region) {
 		//events.sendCompletedEvent('VALIDATE_PRE_BUILD_CONF', "Service exists for deletion")
 	}catch (ex) {
 		if(!((ex.getMessage()).indexOf("groovy.json.internal.LazyMap") > -1)) {
-			updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, region, "deletion_failed");
+			updateServiceInDB(var_db_service_id, "deletion_failed");
 			send_status_email ("FAILED")
 			error "checkServiceExists Failed. "+ex.getMessage()
 		} else {
@@ -412,10 +414,10 @@ def cleanup(repoName) {
 	
 	try {
 		scmModule.deleteProject(repoName)
-		updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "inactive");
+		updateServiceInDB(var_db_service_id, "inactive");
 		send_status_email ("COMPLETED")
 	} catch (ex) {
-		updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_failed");
+		updateServiceInDB(var_db_service_id, "deletion_failed");
 		send_status_email ("FAILED")
 		error "deleteProject failed. "+ex.getMessage()
 	}
@@ -468,7 +470,7 @@ def cleanUpApiGatewayResources(stage, path, region) {
 				//events.sendCompletedEvent('DELETE_API_RESOURCE', "No Resource to be deleted", null, getEnvKey(stage))
 			}
 		} catch(ex) {
-			updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, region, "deletion_failed");
+			updateServiceInDB(var_db_service_id, "deletion_failed");
 			send_status_email ("FAILED")
 			error ex.getMessage()
 		}
@@ -532,7 +534,7 @@ def cleanUpApiDocs(stage, service, domain) {
 			sh "aws s3 rm s3://${apiRootFolder}/${domain}/${service}/${stage} --recursive"
 			//events.sendCompletedEvent('DELETE_API_DOC', null, null, getEnvKey(stage))
 		} catch(ex) {
-			updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_failed");
+			updateServiceInDB(var_db_service_id, "deletion_failed");
 			send_status_email ("FAILED")
 			error "cleanUpApiDocs Failed. "+ex.getMessage()
 		}
@@ -585,7 +587,7 @@ def getResourcePath() {
 		resourcepath = (basePath+"/"+pathInfo).replaceAll("//","/")
 		return resourcepath
 	} catch(ex) {
-		updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_failed");
+		updateServiceInDB(var_db_service_id, "deletion_failed");
 		send_status_email ("FAILED")
 		error "getResourcePath Failed. "+ex.getMessage()
 	}
@@ -615,7 +617,7 @@ def getResourcePath() {
  				cleanupS3BucketPolicy(service, domain, stage, bucketName)
  			}
  		} catch(ex) {
- 			updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_failed");
+ 			updateServiceInDB(var_db_service_id, "deletion_failed");
  			send_status_email ("FAILED")
  			error ex.getMessage()
  		}
@@ -683,7 +685,7 @@ def cleanupS3BucketPolicy(service, domain, stage, bucket) {
 		} catch(ex) {
             resetCredentials()
 			if(ex.getMessage().indexOf("groovy.json.internal.LazyMap") < 0) {
-				updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_failed");
+				updateServiceInDB(var_db_service_id, "deletion_failed");
 				send_status_email ("FAILED")
 				error "cleanupS3BucketPolicy Failed. "+ex.getMessage()
 			}
@@ -748,7 +750,7 @@ def cleanupCloudFrontDistribution(service, domain, stage) {
 				echo "Could not find a CloudFront distribution Id for service: $service and environment $stage"
 				//events.sendCompletedEvent('DELETE_CLOUDFRONT', "CF resource not available", null, getEnvKey(stage))
 			} else {
-				updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_failed");
+				updateServiceInDB(var_db_service_id, "deletion_failed");
 				send_status_email ("FAILED")
 				error "cleanupCloudFrontDistribution Failed. "+ex.getMessage()
 			}
@@ -803,7 +805,7 @@ def getDistributionConfig(distributionID) {
 		)
 		return distributionConfig
 	}catch (ex) {
-		updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_failed");
+		updateServiceInDB(var_db_service_id, "deletion_failed");
 		send_status_email ("FAILED")
 		error "getDistributionConfig Failed."+ex.getMessage()
 	}
@@ -832,7 +834,7 @@ def generateDistributionConfigForDisable(distributionConfig) {
 		}catch(ex) {}
 		return eTag
 	} catch(ex) {
-		updateServiceInDB(var_db_service_id, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "deletion_failed");
+		updateServiceInDB(var_db_service_id, "deletion_failed");
 		send_status_email ("FAILED")
 		error "generateDistributionConfigForDisable Failed."+ex.getMessage()
 	}
@@ -895,9 +897,10 @@ def loadServerlessConfig(String runtime) {
 	sh "cp serverless.yml serverless-temp.yml"
 }
 
-def updateServiceInDB(service_id_in_db, apiID, region, statusval) {
-  sh "curl -H \"Content-Type: application/json\"  -H \"Authorization: "+auth_token+"\" -X PUT -k -v -d \
-  		'{ \"status\": \"${statusval}\"}' https://${apiID}.execute-api.${region}.amazonaws.com/prod/jazz/services/${service_id_in_db}?isAdmin=true"
+def updateServiceInDB(service_id_in_db, statusval) {
+	def apiId = utilModule.getAPIIdForCore(configLoader.AWS.API["PROD"])
+  	sh "curl -H \"Content-Type: application/json\"  -H \"Authorization: "+auth_token+"\" -X PUT -k -v -d \
+  		'{ \"status\": \"${statusval}\"}' https://${apiId}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod/jazz/services/${service_id_in_db}?isAdmin=true"
 }
 
 
@@ -1016,11 +1019,11 @@ def loadServiceInfo() {
  }
 
 /*
-* Load environment variables from build module
+* Load build modules
 */
-def loadConfigModule(buildModuleUrl){
+def loadBuildModules(buildModuleUrl){
 
-	dir('config-loader') {
+	dir('build_modules') {
 		checkout([$class: 'GitSCM', branches: [
 			[name: '*/master']
 		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
@@ -1030,6 +1033,11 @@ def loadConfigModule(buildModuleUrl){
 		def resultJsonString = readFile("jazz-installer-vars.json")
 		configModule = load "config-loader.groovy"
 		configLoader = configModule.initialize(resultJsonString)
+
+		scmModule = load "scm-module.groovy"
+		scmModule.initialize(configLoader)
+
+		utilModule = load "utility-loader.groovy"
 	}
 }
 
@@ -1038,28 +1046,25 @@ def loadConfigModule(buildModuleUrl){
  *
  */
 def loadServiceMetadataModule(buildURL) {
-		try {		
+	try {		
 
-			echo "loading serviceMetaData, checking repos"
+		echo "loading serviceMetaData, checking repos"
 
-			dir('service-metadata') {
-				checkout([$class: 'GitSCM', branches: [
-					[name: '*/master']
-				], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-					[credentialsId: configLoader.REPOSITORY.CREDENTIAL_ID, url: buildURL]
-				]])
-				serviceMetadata = load "service-metadata-loader.groovy"
-				serviceMetadata.setAuthToken(setCredentials())
+		dir('service-metadata') {
+			checkout([$class: 'GitSCM', branches: [
+				[name: '*/master']
+			], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
+				[credentialsId: configLoader.REPOSITORY.CREDENTIAL_ID, url: buildURL]
+			]])
+			serviceMetadata = load "service-metadata-loader.groovy"
+			serviceMetadata.setAuthToken(setCredentials())
 
-				// Load and set dependent utility module.
-				echo "loading util module"
-				Util = load "utility-loader.groovy"
-				serviceMetadata.setUtil(Util)
-			}
-		return serviceMetadata
-		}catch(ex) {
-			error "loadServiceMetadataModule Failed. "+ex.getMessage()
+			serviceMetadata.setUtil(utilModule)
 		}
+	return serviceMetadata
+	}catch(ex) {
+		error "loadServiceMetadataModule Failed. "+ex.getMessage()
+	}
 }
 
 def initialize(serviceMetadata, serviceType, service, domain){
@@ -1070,27 +1075,6 @@ def initialize(serviceMetadata, serviceType, service, domain){
 	
 	serviceMetadata.initialize(serviceType, service, domain, url, dev, stg, prd)
 	serviceMetadata.setUrl(url)
-}
-
-/*
-load scm module
-*/
-def loadSCMModule(buildModuleUrl){
-
-	try {	
-		dir('scm-loader') {
-			checkout([$class: 'GitSCM', branches: [
-				[name: '*/master']
-			], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-				[credentialsId: repo_credential_id, url: buildModuleUrl]
-			]])
-
-			scmModule = load "scm-module.groovy"
-			scmModule.initialize(configLoader)
-		}
-	}catch(ex) {
-		error "loadSCMModule failed " + ex.toString()
-	}
 }
 
 def getBuildModuleUrl() {

--- a/jazz-build-module/utility-loader.groovy
+++ b/jazz-build-module/utility-loader.groovy
@@ -69,7 +69,7 @@ getAPIId takes api Id mapping document and a config object to return an API Id
 */
 
 def getAPIId(apiIdMapping, config) {
-	return getAPIId(apiIdMapping, config["domain"], config["service"])
+	return getAPIId(apiIdMapping, config['domain'], config['service'])
 }
 
 def getAPIId(apiIdMapping, namespace, service) {

--- a/jazz-build-module/utility-loader.groovy
+++ b/jazz-build-module/utility-loader.groovy
@@ -64,5 +64,33 @@ def parseJson(def json) {
     new groovy.json.JsonSlurperClassic().parseText(json)
 }
 
+/**
+getAPIId takes api Id mapping document and a config object to return an API Id
+*/
+
+def getAPIId(apiIdMapping, config) {
+	return getAPIId(apiIdMapping, config["domain"], config["service"])
+}
+
+def getAPIId(apiIdMapping, namespace, service) {
+	if (!apiIdMapping) {
+		error "No mapping document provided to lookup API Id!!"
+	}
+
+	if (apiIdMapping["${namespace}_${service}"]) {
+		return apiIdMapping["${namespace}_${service}"];
+	}else if (apiIdMapping["${namespace}_*"]) {
+		return apiIdMapping["${namespace}_*"];
+	}else {
+		apiIdMapping["*"];
+	}   
+}
+
+/**
+getAPIIdForCore is a helper method to get apiId for jazz core services
+*/
+def getAPIIdForCore(apiIdMapping) {
+	return getAPIId(apiIdMapping, "jazz", "*")
+}
 
 return this

--- a/jenkins-build-pack-api/Jenkinsfile
+++ b/jenkins-build-pack-api/Jenkinsfile
@@ -44,6 +44,7 @@ def Event_Status = [
 @Field def configLoader
 @Field def scmModule
 @Field def serviceConfigdata
+@Field def utilModule
 
 @Field def auth_token = ''
 @Field def g_svc_admin_cred_ID = 'SVC_ADMIN'
@@ -57,7 +58,7 @@ node() {
 	def jazzBuildModuleURL = getBuildModuleUrl()
 	loadBuildModule(jazzBuildModuleURL)
 
-	def jazz_prod_api_id = getAPIId(configLoader.AWS.API["PROD"], "jazz", "*")
+	def jazz_prod_api_id = utilModule.getAPIIdForCore(configLoader.AWS.API["PROD"])
 	g_base_url = "https://${jazz_prod_api_id}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod"
 	g_base_url_for_swagger = "http://editor.swagger.io/?url=http://${configLoader.AWS.S3.API_DOC}.s3-website-${configLoader.AWS.REGION}.amazonaws.com/"
 
@@ -186,7 +187,7 @@ node() {
 				if (fileExists('swagger/swagger.json')) {
 					echo "Generating swagger file for environment: ${env_key}"
 	                
-					def api_id = getAPIId(configLoader.AWS.API[env_key], config)
+					def api_id = utilModule.getAPIId(configLoader.AWS.API[env_key], config)
 					
 					def apiHostName = "${api_id}.execute-api.${configLoader.AWS.REGION}.amazonaws.com" 
 					generateSwaggerEnv(current_environment, "${configLoader.INSTANCE_PREFIX}-${current_environment}", apiHostName,config)
@@ -677,23 +678,6 @@ def getBuildModuleUrl() {
     }
 }
 
-/**
-getAPIId takes api Id mapping document and a config object to return an API Id
-*/
-def getAPIId(apiIdMapping, config) {
-	if (!apiIdMapping) {
-		error "No mapping document provided to lookup API Id!!"
-	}
-
-	if (apiIdMapping["${config['domain']}_${config['service']}"]) {
-		return apiIdMapping["${config['domain']}_${config['service']}"];
-	}else if (apiIdMapping["${config['domain']}_*"]) {
-		return apiIdMapping["${config['domain']}_*"];
-	}else {
-		apiIdMapping["*"];
-	}   
-}
-
 /*
 * Load environment variables from build module
 */
@@ -714,6 +698,8 @@ def loadBuildModule(buildModuleUrl){
 		scmModule.initialize(configLoader)
 
 		serviceConfigdata = load "service-configuration-data-loader.groovy"
+
+		utilModule = load "utility-loader.groovy"
 
 	}
 }

--- a/jenkins-build-pack-api/Jenkinsfile
+++ b/jenkins-build-pack-api/Jenkinsfile
@@ -11,7 +11,6 @@ import groovy.transform.Field
 @Field def scm_type
 
 
-
 //definitions
 def Event_Name =[
 	'MODIFY_TEMPLATE':'MODIFY_TEMPLATE',
@@ -58,7 +57,8 @@ node() {
 	def jazzBuildModuleURL = getBuildModuleUrl()
 	loadBuildModule(jazzBuildModuleURL)
 
-	g_base_url = "https://${configLoader.AWS.API.PROD_ID}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod"
+	def jazz_prod_api_id = getAPIId(configLoader.AWS.API["PROD"], "jazz", "*")
+	g_base_url = "https://${jazz_prod_api_id}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod"
 	g_base_url_for_swagger = "http://editor.swagger.io/?url=http://${configLoader.AWS.S3.API_DOC}.s3-website-${configLoader.AWS.REGION}.amazonaws.com/"
 
     echo "Build triggered via branch: " + params.scm_branch
@@ -164,7 +164,7 @@ node() {
 		}
 		stage("Deployment to ${env_key} environment") {
 			sendEvent(service, branch, runtime, env_key, configLoader.AWS.REGION, domain, configLoader.AWS.ROLEID, Event_Name.DEPLOY_TO_AWS, Event_Status.STARTED, "starting")
-			echo "starts Deployment to ${env_key} Env"
+			echo "starts deployment to ${env_key} Env"
 
 			withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: configLoader.AWS_CREDENTIAL_ID, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
 				echo "AWS Configure ......."
@@ -184,20 +184,20 @@ node() {
 				sh "serverless deploy --stage ${current_environment} -v --bucket ${configLoader.AWS.S3[envBucketKey]}"
 
 				if (fileExists('swagger/swagger.json')) {
-					// Generate swagger file based on environment
-					echo "Generating the swagger file for each environment"
-
-					def api_key = env_key + "_ID"
-					def apiHostName = "${configLoader.AWS.API[api_key]}.execute-api.${configLoader.AWS.REGION}.amazonaws.com" //Staging environment
+					echo "Generating swagger file for environment: ${env_key}"
+	                
+					def api_id = getAPIId(configLoader.AWS.API[env_key], config)
+					
+					def apiHostName = "${api_id}.execute-api.${configLoader.AWS.REGION}.amazonaws.com" 
 					generateSwaggerEnv(current_environment, "${configLoader.INSTANCE_PREFIX}-${current_environment}", apiHostName,config)
 
 					echo "Deploying to API Gateway environment.."
-					sh "aws apigateway put-rest-api --rest-api-id ${configLoader.AWS.API[api_key]} --mode merge --parameters basepath=prepend --body 'file://swagger/swagger.json'"+" --profile cloud-api"
-					sh "aws apigateway create-deployment --rest-api-id ${configLoader.AWS.API[api_key]} --stage-name ${current_environment} --profile cloud-api"
+					sh "aws apigateway put-rest-api --rest-api-id ${api_id} --mode merge --parameters basepath=prepend --body 'file://swagger/swagger.json'"+" --profile cloud-api"
+					sh "aws apigateway create-deployment --rest-api-id ${api_id} --stage-name ${current_environment} --profile cloud-api"
 
-					sh "aws apigateway tag-resource --resource-arn arn:aws:apigateway:${configLoader.AWS.REGION}::/restapis/${configLoader.AWS.API[api_key]}/stages/${current_environment} --tags Application=Jazz,JazzInstance=${configLoader.INSTANCE_PREFIX}  --profile cloud-api"
+					sh "aws apigateway tag-resource --resource-arn arn:aws:apigateway:${configLoader.AWS.REGION}::/restapis/${api_id}/stages/${current_environment} --tags Application=Jazz,JazzInstance=${configLoader.INSTANCE_PREFIX}  --profile cloud-api"
 
-					def endpointUrl = "https://${configLoader.AWS.API[api_key]}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/${current_environment}/" + domain + "/" + config['service']
+					def endpointUrl = "https://${apiHostName}/${current_environment}/" + domain + "/" + config['service']
 
 					if(domain != "jazz"){
 						createSubscriptionFilters(stackName, configLoader.AWS.REGION,roleId);
@@ -676,6 +676,24 @@ def getBuildModuleUrl() {
       return "http://${repo_base}/scm/${repo_core}/jazz-build-module.git"
     }
 }
+
+/**
+getAPIId takes api Id mapping document and a config object to return an API Id
+*/
+def getAPIId(apiIdMapping, config) {
+	if (!apiIdMapping) {
+		error "No mapping document provided to lookup API Id!!"
+	}
+
+	if (apiIdMapping["${config['domain']}_${config['service']}"]) {
+		return apiIdMapping["${config['domain']}_${config['service']}"];
+	}else if (apiIdMapping["${config['domain']}_*"]) {
+		return apiIdMapping["${config['domain']}_*"];
+	}else {
+		apiIdMapping["*"];
+	}   
+}
+
 /*
 * Load environment variables from build module
 */

--- a/jenkins-build-pack-api/Jenkinsfile
+++ b/jenkins-build-pack-api/Jenkinsfile
@@ -56,7 +56,7 @@ def Event_Status = [
 
 node() {
 	def jazzBuildModuleURL = getBuildModuleUrl()
-	loadBuildModule(jazzBuildModuleURL)
+	loadBuildModules(jazzBuildModuleURL)
 
 	def jazz_prod_api_id = utilModule.getAPIIdForCore(configLoader.AWS.API["PROD"])
 	g_base_url = "https://${jazz_prod_api_id}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod"
@@ -679,9 +679,9 @@ def getBuildModuleUrl() {
 }
 
 /*
-* Load environment variables from build module
+* Load build modules
 */
-def loadBuildModule(buildModuleUrl){
+def loadBuildModules(buildModuleUrl){
 
 	dir('config-loader') {
 		checkout([$class: 'GitSCM', branches: [
@@ -700,6 +700,5 @@ def loadBuildModule(buildModuleUrl){
 		serviceConfigdata = load "service-configuration-data-loader.groovy"
 
 		utilModule = load "utility-loader.groovy"
-
 	}
 }

--- a/jenkins-build-pack-lambda/Jenkinsfile
+++ b/jenkins-build-pack-lambda/Jenkinsfile
@@ -52,6 +52,8 @@ def Event_Status = [
 @Field def configLoader
 @Field def scmModule
 @Field def serviceConfigdata
+@Field def utilModule
+
 @Field def auth_token = ''
 @Field def g_base_url = ''
 @Field def g_svc_admin_cred_ID = 'SVC_ADMIN'
@@ -59,9 +61,10 @@ def Event_Status = [
 @Field def stack_name
 node ()  {
 	def jazzBuildModuleURL = getBuildModuleUrl()
-	loadBuildModule(jazzBuildModuleURL)
+	loadBuildModules(jazzBuildModuleURL)
 
-    g_base_url ="https://${configLoader.AWS.API.PROD_ID}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod"
+    def jazz_prod_api_id = utilModule.getAPIIdForCore(configLoader.AWS.API["PROD"])
+	g_base_url = "https://${jazz_prod_api_id}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod"
 	
 	echo "Build triggered via branch: " + params.scm_branch + " with params " + params
 	def _event = ""
@@ -742,9 +745,9 @@ def updatePlatformServiceTemplate(config,roleARN,roleId,current_environment,repo
 	serviceConfigdata.loadServiceConfigurationData()
 }
 /*
-* Load environment variables from build module
+* Load build modules
 */
-def loadBuildModule(buildModuleUrl){
+def loadBuildModules(buildModuleUrl){
 
 	dir('config-loader') {
 		checkout([$class: 'GitSCM', branches: [
@@ -761,11 +764,10 @@ def loadBuildModule(buildModuleUrl){
 		scmModule.initialize(configLoader)
 		
 		serviceConfigdata = load "service-configuration-data-loader.groovy"
-		
+
+		utilModule = load "utility-loader.groovy"
 	}
 }
-
-
 
 def getBuildModuleUrl() {
     if (scm_type && scm_type != "bitbucket") {

--- a/jenkins-build-pack-website/Jenkinsfile
+++ b/jenkins-build-pack-website/Jenkinsfile
@@ -41,6 +41,7 @@ def Event_Status = [
 @Field def configModule
 @Field def configLoader
 @Field def scmModule
+@Field def utilModule
 
 @Field def g_login_token = ''
 @Field def g_base_url = ''
@@ -54,10 +55,11 @@ def Event_Status = [
 
 node ()  {
 	def jazzBuildModuleURL = getBuildModuleUrl()
-	loadConfigModule(jazzBuildModuleURL)
-	loadSCMModule(jazzBuildModuleURL)
+	loadBuildModules(jazzBuildModuleURL)
 
-	g_base_url = "https://${configLoader.AWS.API.PROD_ID}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod"
+	def jazz_prod_api_id = utilModule.getAPIIdForCore(configLoader.AWS.API["PROD"])
+
+	g_base_url = "https://${jazz_prod_api_id}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod"
 	
 	echo "Build Pack website params: " + params
 
@@ -198,7 +200,7 @@ node ()  {
 						}
 					} else{
 						loadBucketPolicy(service, s3Bucket, false)
-						url = "https://s3.amazonaws.com/" + s3ProdBucket + "/${service}/index.html"
+						url = "https://s3.amazonaws.com/${s3ProdBucket}/${service}/index.html"
 						updateServiceWithEndpointInfo(config['service'], domain, g_base_url + '/jazz/services', environment, url)
 					}
 
@@ -334,7 +336,7 @@ node ()  {
 						}
 					}else{
 						loadBucketPolicy(service, s3Bucket,false)
-						url = "https://s3.amazonaws.com/" + s3DevBucket + "/${service}/index.html"
+						url = "https://s3.amazonaws.com/${s3DevBucket}/${service}/index.html"
 						updateServiceWithEndpointInfo(config['service'], domain, g_base_url + '/jazz/services', environment, url)
 					}
 					def svc_status = 'You can access your website using following link: ' + url
@@ -813,24 +815,6 @@ def send_status_email (email_id, build_status, service, email_content) {
    	}
 }
 
-/*
-* Load environment variables from build module
-*/
-def loadConfigModule(buildModuleUrl){
-
-	dir('config-loader') {
-		checkout([$class: 'GitSCM', branches: [
-			[name: '*/master']
-		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-			[credentialsId: repo_credential_id, url: buildModuleUrl]
-		]])
-
-		def resultJsonString = readFile("jazz-installer-vars.json")
-		configModule = load "config-loader.groovy"
-		configLoader = configModule.initialize(resultJsonString)
-	}
-}
-
 /**
  * Non-lazy JSON parser
  */
@@ -870,27 +854,6 @@ def loadServiceMetadataModule(buildURL) {
 	}
 }
 
-/*
-load scm module
-*/
-def loadSCMModule(buildModuleUrl){
-
-	try {	
-		dir('scm-loader') {
-			checkout([$class: 'GitSCM', branches: [
-				[name: '*/master']
-			], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-				[credentialsId: repo_credential_id, url: buildModuleUrl]
-			]])
-
-			scmModule = load "scm-module.groovy"
-			scmModule.initialize(configLoader)
-		}
-	}catch(ex) {
-		error "loadSCMModule failed: " + ex.toString()
-	}
-}
-
 def getBuildModuleUrl() {
     if (scm_type && scm_type != "bitbucket") {
       // right now only bitbucket has this additional tag scm in its git clone path
@@ -904,4 +867,29 @@ def getBuildModuleUrl() {
 def jsonParse(jsonString) {
     def nonLazyMap = new groovy.json.JsonSlurperClassic().parseText(jsonString)
     return nonLazyMap
+}
+
+/*
+* Load environment variables from build module
+*/
+def loadBuildModules(buildModuleUrl){
+
+	dir('build_modules') {
+		checkout([$class: 'GitSCM', branches: [
+			[name: '*/master']
+		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
+			[credentialsId: repo_credential_id, url: buildModuleUrl]
+		]])
+
+		def resultJsonString = readFile("jazz-installer-vars.json")
+		configModule = load "config-loader.groovy"
+		configLoader = configModule.initialize(resultJsonString)
+
+		scmModule = load "scm-module.groovy"
+		scmModule.initialize(configLoader)
+
+		serviceConfigdata = load "service-configuration-data-loader.groovy"
+
+		utilModule = load "utility-loader.groovy"
+	}
 }

--- a/service-onboarding-build-pack/Jenkinsfile
+++ b/service-onboarding-build-pack/Jenkinsfile
@@ -443,14 +443,12 @@ def sendEvent(service_type, service_name, domain, runtime, admin_group, event_na
 }
 
 def updateServiceInDB(service_id_in_db, statusval) {
-	def apiId = utilModule.getAPIIdForCore(configLoader.AWS.API["PROD"])
-  	sh "curl -H \"Content-Type: application/json\" -H \"Authorization: ${auth_token}\" -X PUT -k -v -d '{ \"status\": \"${statusval}\"}' https://${apiId}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod/jazz/services/${service_id_in_db}/"
+	sh "curl -H \"Content-Type: application/json\" -H \"Authorization: ${auth_token}\" -X PUT -k -v -d '{ \"status\": \"${statusval}\"}' ${g_base_url}/jazz/services/${service_id_in_db}/"
 }
 
-def createServiceInDB(service_name, domain, created_by, runtime, repo_url, desc, approver, servicetype, apiID, region,serviceMetadataJson) {
+def createServiceInDB(service_name, domain, created_by, runtime, repo_url, desc, approver, servicetype, serviceMetadataJson) {
 
 	try {
-		def apiId = utilModule.getAPIIdForCore(configLoader.AWS.API["PROD"])
 		
 		def body = JsonOutput.toJson([
 			service:service_name,
@@ -465,7 +463,7 @@ def createServiceInDB(service_name, domain, created_by, runtime, repo_url, desc,
 		])
 		
 		def outputStr = sh (
-			script: "curl -H \"Content-Type: application/json\" -H \"Authorization: ${auth_token} \" -X POST -k -v -d '$body' https://${apiID}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod/jazz/services/",
+			script: "curl -H \"Content-Type: application/json\" -H \"Authorization: ${auth_token} \" -X POST -k -v -d '$body' ${g_base_url}/jazz/services/",
 			returnStdout: true
 		).trim()
 		echo "outputStr===============" + outputStr

--- a/service-onboarding-build-pack/Jenkinsfile
+++ b/service-onboarding-build-pack/Jenkinsfile
@@ -39,6 +39,7 @@ def Event_Status = [
 @Field def configModule
 @Field def configLoader
 @Field def scmModule
+@Field def utilModule
 
 @Field def g_svc_admin_cred_ID = 'SVC_ADMIN'
 @Field def auth_token = ''
@@ -46,10 +47,10 @@ def Event_Status = [
 
 node  {
 	jazzBuildModuleURL = getBuildModuleUrl()
-	loadConfigModule(jazzBuildModuleURL)
-	loadSCMModule(jazzBuildModuleURL)
+	loadBuildModules(jazzBuildModuleURL)
 
-	g_base_url = "https://${configLoader.AWS.API.PROD_ID}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod"
+	def jazz_prod_api_id = utilModule.getAPIIdForCore(configLoader.AWS.API["PROD"])
+	g_base_url = "https://${jazz_prod_api_id}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod"
 	
 	auth_token = getAuthToken()
 
@@ -248,13 +249,13 @@ node  {
 
 				def repo_url = scmModule.getRepoUrl(repo_name)
 
-				service_id_in_db = createServiceInDB(service_name, domain, owner, runtime, repo_url, description, admin_group, service_type, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION,serviceMetadataJson);
+				service_id_in_db = createServiceInDB(service_name, domain, owner, runtime, repo_url, description, admin_group, service_type, serviceMetadataJson);
 				
-				updateServiceInDB(service_id_in_db, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "creation_started");
+				updateServiceInDB(service_id_in_db, "creation_started");
 			}
 		}
 		catch(error){
-			updateServiceInDB(service_id_in_db, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "creation_failed");
+			updateServiceInDB(service_id_in_db, "creation_failed");
 			//do nothing
 		}
 	}
@@ -278,7 +279,7 @@ node  {
 			}
 		}
 		catch(error){
-			updateServiceInDB(service_id_in_db, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "creation_failed");
+			updateServiceInDB(service_id_in_db, "creation_failed");
 
 			send_status_email (owner, "FAILED", service_name, domain)
 
@@ -298,7 +299,7 @@ node  {
 			}
 			catch (error)
 			{
-				updateServiceInDB(service_id_in_db, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "creation_failed");
+				updateServiceInDB(service_id_in_db, "creation_failed");
 
 				send_status_email (owner, "FAILED", service_name, domain)
 
@@ -344,7 +345,7 @@ node  {
 					sendEvent(service_type, service_name, domain, runtime, admin_group, Event_Name.ADD_WEBHOOK, Event_Status.COMPLETED, "")
 				}
 				catch(error){
-					updateServiceInDB(service_id_in_db, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "creation_failed");
+					updateServiceInDB(service_id_in_db, "creation_failed");
 					send_status_email (owner, "FAILED", service_name, domain)
 
 					sendEvent(service_type, service_name, domain, runtime, admin_group, Event_Name.ADD_WEBHOOK, Event_Status.FAILED, error.getMessage())
@@ -362,7 +363,7 @@ node  {
 				}
 				catch (error)
 				{
-					updateServiceInDB(service_id_in_db, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "creation_failed");
+					updateServiceInDB(service_id_in_db, "creation_failed");
 					send_status_email (owner, "FAILED", service_name, domain)
 
 					sendEvent(service_type, service_name, domain, runtime, admin_group, Event_Name.PUSH_TEMPLATE_TO_SERVICE_REPO, Event_Status.FAILED, error.getMessage())
@@ -376,7 +377,7 @@ node  {
 					sendEvent(service_type, service_name, domain, runtime, admin_group, Event_Name.ADD_WRITE_PERMISSIONS_TO_SERVICE_REPO, Event_Status.COMPLETED, "")
 				}
 				catch(error){
-					updateServiceInDB(service_id_in_db, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "creation_failed");
+					updateServiceInDB(service_id_in_db, "creation_failed");
 					sendEvent(service_type, service_name, domain, runtime, admin_group, Event_Name.ADD_WRITE_PERMISSIONS_TO_SERVICE_REPO, Event_Status.FAILED, error.getMessage())
 					echo error
 				}
@@ -387,7 +388,7 @@ node  {
 					sendEvent(service_type, service_name, domain, runtime, admin_group, Event_Name.LOCK_MASTER_BRANCH, Event_Status.COMPLETED, "")
 				}
 				catch(error){
-					updateServiceInDB(service_id_in_db, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "creation_failed");
+					updateServiceInDB(service_id_in_db, "creation_failed");
 
 					send_status_email (owner, "FAILED", service_name, domain)
 
@@ -396,7 +397,7 @@ node  {
 				}				
 
 				echo "Calling update row in db ###################################################"
-				updateServiceInDB(service_id_in_db, configLoader.AWS.API.PROD_ID, configLoader.AWS.REGION, "creation_completed");
+				updateServiceInDB(service_id_in_db, "creation_completed");
 			}
 		}
 	}
@@ -441,13 +442,15 @@ def sendEvent(service_type, service_name, domain, runtime, admin_group, event_na
 	echo "send event" + error
 }
 
-def updateServiceInDB(service_id_in_db, apiId, region, statusval) {
-  sh "curl -H \"Content-Type: application/json\" -H \"Authorization: ${auth_token}\" -X PUT -k -v -d '{ \"status\": \"${statusval}\"}' https://${apiId}.execute-api.${region}.amazonaws.com/prod/jazz/services/${service_id_in_db}/"
+def updateServiceInDB(service_id_in_db, statusval) {
+	def apiId = utilModule.getAPIIdForCore(configLoader.AWS.API["PROD"])
+  	sh "curl -H \"Content-Type: application/json\" -H \"Authorization: ${auth_token}\" -X PUT -k -v -d '{ \"status\": \"${statusval}\"}' https://${apiId}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod/jazz/services/${service_id_in_db}/"
 }
 
 def createServiceInDB(service_name, domain, created_by, runtime, repo_url, desc, approver, servicetype, apiID, region,serviceMetadataJson) {
 
 	try {
+		def apiId = utilModule.getAPIIdForCore(configLoader.AWS.API["PROD"])
 		
 		def body = JsonOutput.toJson([
 			service:service_name,
@@ -462,20 +465,20 @@ def createServiceInDB(service_name, domain, created_by, runtime, repo_url, desc,
 		])
 		
 		def outputStr = sh (
-			script: "curl -H \"Content-Type: application/json\" -H \"Authorization: ${auth_token} \" -X POST -k -v -d '$body' https://${apiID}.execute-api.${region}.amazonaws.com/prod/jazz/services/",
+			script: "curl -H \"Content-Type: application/json\" -H \"Authorization: ${auth_token} \" -X POST -k -v -d '$body' https://${apiID}.execute-api.${configLoader.AWS.REGION}.amazonaws.com/prod/jazz/services/",
 			returnStdout: true
 		).trim()
 		echo "outputStr===============" + outputStr
 		def jsonParser = new groovy.json.JsonSlurper()
 		def resultJson = jsonParser.parseText(outputStr)
 		if(resultJson == null || resultJson.data == null || resultJson.data.service_id == null) {
-			error "jazz/services/ Insert failed"
+			error "jazz/services/insert failed"
 		}
 		return resultJson.data.service_id;
 	}catch (ex) {
 		if(!((ex.getMessage()).indexOf("groovy.json.internal.LazyMap") > -1)) {
 			//events.sendFailureEvent('VALIDATE_PRE_BUILD_CONF', ex.getMessage())
-			error "createServiceInDB Failed. "+ex.getMessage()
+			error "createServiceInDB failed: "+ex.getMessage()
 		} else {
 			//events.sendCompletedEvent('VALIDATE_PRE_BUILD_CONF', "Service exists for deletion")
 		}
@@ -587,10 +590,10 @@ def parseJson(jsonString) {
 /*
 * Load environment variables from build module
 */
-def loadConfigModule(buildModuleUrl){
+def loadBuildModules(buildModuleUrl){
 	echo "loading env variables, checking repos..."
 
-	dir('config-loader') {
+	dir('build_modules') {
 		checkout([$class: 'GitSCM', branches: [
 			[name: '*/master']
 		], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
@@ -602,28 +605,11 @@ def loadConfigModule(buildModuleUrl){
 		def resultJsonString = readFile("jazz-installer-vars.json")
 		configModule = load "config-loader.groovy"
 		configLoader = configModule.initialize(resultJsonString)
-		echo "finished loading env module"
-	}
-}
+		
+		scmModule = load "scm-module.groovy"
+		scmModule.initialize(configLoader)
 
-/*
-load scm module
-*/
-def loadSCMModule(buildModuleUrl){
-
-	try {	
-		dir('scm-loader') {
-			checkout([$class: 'GitSCM', branches: [
-				[name: '*/master']
-			], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [
-				[credentialsId: repo_credential_id, url: buildModuleUrl]
-			]])
-
-			scmModule = load "scm-module.groovy"
-			scmModule.initialize(configLoader)
-		}
-	}catch(ex) {
-		error "loadSCMModule failed " + ex.toString()
+		utilModule = load "utility-loader.groovy"
 	}
 }
 


### PR DESCRIPTION
### Requirements
* Jazz platform should allow users to create APIs beyond 300 resources (AWS Limit)
* Segregate Jazz platform API's from user APIs
* Allow Jazz Admins/Users choose **namespace** specific API endpoints
* Allow Jazz Admins/Users to choose **service** specific API endpoints

### Description of the Change

* [API Gateway Limits](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html) have limited Jazz customers from creating API endpoints. Specifically the "Resources Per API" limit of 300 limits the capability of Jazz to be used as a platform.
* Jazz Admins can specify a general bucket, per namespace, per service specific API endpoints through the configuration file. These specifications are applied for PROD, STG and DEV categories.
* By default one endpoint is created for each of PROD, STG and DEV categories. 

### Benefits

* Jazz platform will allow users to create APIs beyond 300 resources (AWS Limit)
* Jazz Admins can choose to segregate Jazz platform API's from user APIs
* Jazz Admins can choose **namespace** specific API endpoints
* Jazz Admins can choose **service** specific API endpoints

### Possible Drawbacks

* Jazz Admins have to apply the changes though a JSON config file