### PR TITLE
Removed side pannel : US325718

### DIFF
--- a/jazz-ui/src/app/pages/services/services.component.html
+++ b/jazz-ui/src/app/pages/services/services.component.html
@@ -2,7 +2,8 @@
     <div class="view-hdr-wrp">
         <jazz-header class="hide-for-mobile"></jazz-header>
     </div>
-    <side-tile-fixed [inputData]="recentActivities" [actState]='mobSecState'></side-tile-fixed>
+    <!-- Commenting this to remove the side pannel |uncomment back to get the side pannel - make corresponding css(width) changes for services-content-wrp class  -->
+    <!-- <side-tile-fixed [inputData]="recentActivities" [actState]='mobSecState'></side-tile-fixed> -->
     
     <div class="view-container" [class.translate-for-mob]="mobSecState == 2">
         <div class="services-content-wrp">

--- a/jazz-ui/src/app/pages/services/services.component.scss
+++ b/jazz-ui/src/app/pages/services/services.component.scss
@@ -1,7 +1,8 @@
 @import './../../../main-styles';
 .services-content-wrp {
   width: 80%; //fallback
-  width: calc(100% - 300px);
+  width: calc(100% - 300px);// with side pannel |Overriding for now to remove sidepannel 
+  width:100%;
   display: inline-block;
   padding: 0 37px 0px 37px;
   float: left; // min-height: 100vh;


### PR DESCRIPTION
US325718

Description :
When a user logins into Jazz, the dashboard page shows "Recent Activity" panel on the right side with "Coming Soon" overlay. This is taking up space, so we will remove it and have the services page expand to take up that space.

Acceptance criteria : 
1. When a user logs in successfully to Jazz, user no longer sees "Recent Activity" panel on the right side with "Coming Soon" overlay.
2.  Service page expands to take up the space left from "Recent Activity" panel

Deployed URL : http://d33d77x5n29pgp.cloudfront.net/