### PR TITLE
Bug fix for users who have mixed case email address

### DIFF
--- a/jazz_usermanagement/index.js
+++ b/jazz_usermanagement/index.js
@@ -289,5 +289,5 @@ function updatePassword(cognitoClient, config, userData) {
 
 function getRequestToCreateSCMUser(config, userData) {
 	var scm = new scmFactory(config);
-	return scm.addUserRequest(userData.userid, userData.userpassword);
+	return scm.addUserRequest(userData.userid.toLowerCase(), userData.userpassword);
 }


### PR DESCRIPTION
### Description of the Change

When users register with email address with mixed casing, create services flow breaks as the user is registered with all lower case while the user is added to SCM with mixed casing.

### Benefits

Users with mixed casing in their email address can create services

### Possible Drawbacks
None
