### PR TITLE
fix bug with website build

### DIFF
--- a/jazz-build-module/scm-module.groovy
+++ b/jazz-build-module/scm-module.groovy
@@ -257,7 +257,9 @@ def parseJson(jsonString) {
 }
 
 def getRepoCommitHash() {
-    return sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+    dir(getRepoName()) {
+        return sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+    }
 }
 
 def getRepoName(){


### PR DESCRIPTION
### Description of the Change

Website build fails with error below:

fatal: Not a git repository (or any parent up to mount point /var/lib/jenkins)

This seems to happen as the command for git commit hash isn't running in cwd.

### Benefits

Website build will work 

### Possible Drawbacks

None