### PR TITLE
assets pagination disabled, and env_logs page bug fix

### DIFF
--- a/core/jazz-ui/src/app/pages/environment-assets/env-assets-section.component.ts
+++ b/core/jazz-ui/src/app/pages/environment-assets/env-assets-section.component.ts
@@ -22,7 +22,7 @@ import { environment as env_internal } from './../../../environments/environment
 export class EnvAssetsSectionComponent implements OnInit {
 
 	 state: string = 'default';
-   showPaginationtable: boolean = true;
+   showPaginationtable: boolean = false;
    currentlyActive: number = 1;
 	 totalPageNum: number = 12;
 	 offset:number = 0;
@@ -187,7 +187,7 @@ export class EnvAssetsSectionComponent implements OnInit {
 				service: this.service.name,
 				domain: this.service.domain,
 				environment: this.env,
-				limit:10,
+				// limit:10,
 				
 				};
 				if(this.offsetval > 0){

--- a/core/jazz-ui/src/app/pages/environment-detail/environment-detail.component.scss
+++ b/core/jazz-ui/src/app/pages/environment-detail/environment-detail.component.scss
@@ -37,8 +37,8 @@
     /deep/ .tabs-wrap {
       ul li {
         &:last-child {
-          pointer-events: none;
-          opacity: 0.6;
+          // pointer-events: none;
+          // opacity: 0.6;
         }
       }
     }

--- a/core/jazz-ui/src/app/pages/environment-logs/env-logs-section.component.ts
+++ b/core/jazz-ui/src/app/pages/environment-logs/env-logs-section.component.ts
@@ -424,8 +424,9 @@ export class EnvLogsSectionComponent implements OnInit {
 		}
 		this.subscription = this.http.post('/jazz/logs', this.payload).subscribe(
 			response => {
-				this.logs = response.data.logs;
-				if (this.logs.length != 0) {
+				this.logs = response.data.logs  || response.data.data.logs;
+				if(this.logs != undefined)
+				if (this.logs && this.logs.length != 0) {
 					var pageCount = response.data.count;
 					if (pageCount) {
 						this.totalPagesTable = Math.ceil(pageCount / this.limitValue);


### PR DESCRIPTION
### Requirements



### Description of the Change
Pagination support from UI for the assets tab under environments is disabled.
Few other minor bug fixes regarding the logs tab under environments page.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
