### PR TITLE
Pull request for enabling slack support in create service (config driven)

### DIFF
--- a/core/jazz-ui/Jenkinsfile_Platform
+++ b/core/jazz-ui/Jenkinsfile_Platform
@@ -90,6 +90,7 @@ node ()  {
       sh "sed -i 's/{API_GATEWAY_KEY_PROD}/${jazz_prod_api_id}/g' ./src/environments/environment.oss.ts"
       sh "sed -i 's/{inst_region}/${config_loader.AWS.REGION}/g' ./src/environments/environment.oss.ts"
       sh "sed -i 's/{multi_env}/${config_loader.UI_CONFIG.feature.multi_env}/g' ./src/environments/environment.oss.ts"
+      sh "sed -i 's/{slack_support}/${config_loader.UI_CONFIG.feature.slack_support}/g' ./src/environments/environment.oss.ts"
       
       def envFile = readFile('./src/environments/environment.oss.ts');
       echo "displaying env file :"

--- a/core/jazz-ui/src/app/pages/service-overview/service-overview.component.html
+++ b/core/jazz-ui/src/app/pages/service-overview/service-overview.component.html
@@ -172,7 +172,7 @@
         </ul>
     <ul class="section-right col-md-6 col-sm-12">
        
-        <li *ngIf='internal_build'>
+        <li *ngIf='SlackEnabled'>
         <div class="det-label">Slack Channel</div>
         <div class="det-value" [class.link]='!slackChannel_empty' [ngClass]="{PlaceHolder:slackChannel_empty}"  (click)="slack_link()">{{service.slackChannel || 'Feeling collaborative? Add it to slack'}}</div>
         </li>

--- a/core/jazz-ui/src/app/pages/service-overview/service-overview.component.ts
+++ b/core/jazz-ui/src/app/pages/service-overview/service-overview.component.ts
@@ -14,6 +14,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { ServiceDetailComponent } from '../service-detail/service-detail.component'
 import { environment } from './../../../environments/environment';
 import {  environment as env_internal } from './../../../environments/environment.internal';
+import { environment as env_oss } from './../../../environments/environment.oss';
 
 
 declare var $: any;
@@ -817,7 +818,9 @@ export class ServiceOverviewComponent implements OnInit {
   }
   frndload(event) {}
   is_multi_env: boolean = false;
+  SlackEnabled:boolean = false;
   ngOnInit() {
+    if(env_oss.slack_support) this.SlackEnabled=true;
     if (environment.envName == 'oss')
       if (!environment.multi_env)
         this.multiENV = false;

--- a/core/jazz-ui/src/app/secondary-components/create-service/oss/create-service.component.html
+++ b/core/jazz-ui/src/app/secondary-components/create-service/oss/create-service.component.html
@@ -178,9 +178,9 @@
                     <div class="col-lg-8 col-md-8">
                         <section class="col-lg-12  pad-left0">
                             <div class="input-field-container">
-                                <div class="slack-checkbox custom-cb disable-event">
-                                    <input type="checkbox" id="checkbox-slack" class="ng-untouched ng-valid ng-dirty ng-valid-parse" disabled aria-invalid="false" [checked]="slackSelected" (change)="slackSelected = !slackSelected">
-                                    <label for="checkbox-slack" class="disble"></label>
+                                <div class="slack-checkbox custom-cb" [class.disable-event]='!SlackEnabled'>
+                                    <input type="checkbox" id="checkbox-slack" class="ng-untouched ng-valid ng-dirty ng-valid-parse" [disabled]='!SlackEnabled' aria-invalid="false" [checked]="slackSelected" (change)="slackSelected = !slackSelected">
+                                    <label for="checkbox-slack" [class.disble]='!SlackEnabled'></label>
                                     <div class="cb-status-dets"> Do you want us to notify you through #Slack?</div>
                                 </div>
                                 <div *ngIf="slackSelected == true">

--- a/core/jazz-ui/src/app/secondary-components/create-service/oss/create-service.component.ts
+++ b/core/jazz-ui/src/app/secondary-components/create-service/oss/create-service.component.ts
@@ -28,7 +28,8 @@ export class CreateServiceComponent implements OnInit {
 
   @Output() onClose:EventEmitter<boolean> = new EventEmitter<boolean>();
 
-docs_link = env_oss.urls.docs_link;
+  SlackEnabled:boolean = false;
+  docs_link = env_oss.urls.docs_link;
   typeOfService:string = "api";
   typeOfPlatform:string = "aws";
   disablePlatform = true;
@@ -549,6 +550,7 @@ docs_link = env_oss.urls.docs_link;
 
   ngOnInit() {
     this.getData();
+    if(env_oss.slack_support) this.SlackEnabled=true;
   };
     // cron validation related functions //
 

--- a/core/jazz-ui/src/environments/environment.oss.ts
+++ b/core/jazz-ui/src/environments/environment.oss.ts
@@ -5,6 +5,7 @@ export const environment = {
   api_doc_name : "https://{api_doc_name}.s3.amazonaws.com",
   envName:"oss",
   multi_env:{multi_env},
+  slack_support:{slack_support},
   serviceTabs:["{overview}","{access control}","{metrics}","{logs}","{cost}"],
   environmentTabs:["{env_overview}","{deployments}","{code quality}","{assets}","{env_logs}"],
   urls:{


### PR DESCRIPTION
### Requirements



### Description of the Change

Enabling slack support in UI (create-service) from config value from jazz_installer_vars 

### Benefits

Will be able to add slack channel to services created

### Possible Drawbacks


### Applicable Issues

