### PR TITLE
Bugfix/svc prod config

### DIFF
--- a/core/jazz_services/config/prod-config.json
+++ b/core/jazz_services/config/prod-config.json
@@ -1,5 +1,5 @@
 {
-    "services_table": "{inst_stack_prefix}_services-prod",
+    "services_table": "{inst_stack_prefix}_services_prod",
     "service_required_fields": ["service", "domain", "type", "created_by", "runtime", "status"],
     "service_update_fields": ["description", "email", "slack_channel", "tags", "repository", "status","metadata","is_public_endpoint"],
     "service_filter_params": ["service", "domain", "region", "type", "runtime", "created_by", "status"],


### PR DESCRIPTION
Prod config for services had hyphen for the table name which is suppose to be underscore. This issue happened while porting code into apigee extension. 

Fixing it will allow Jazz services api to function properly and will be able to query the dynamo db table.