### PR TITLE
Remove copyright headers from template files

### DIFF
--- a/builds/jenkins-build-pack-lambda/Jenkinsfile
+++ b/builds/jenkins-build-pack-lambda/Jenkinsfile
@@ -414,7 +414,7 @@ def validateDeploymentConfigurations(def prop) {
 		if (_runtime == "") {
 			error "Wrong configuration. Value for Key 'providerRuntime' is missing in the configuration"
 		} else {
-			def validRuntimes = ["nodejs4.3", "nodejs6.10", "python2.7", "java8"] //@TODO. Add more runtime supports. DSundar3
+			def validRuntimes = ["nodejs4.3", "nodejs6.10", "python2.7", "java8"] //@TODO. Add more runtime supports.
 			def flag = false
 
 			for (int i = 0; i < validRuntimes.size(); i++) {

--- a/templates/api-template-nodejs/components/config.js
+++ b/templates/api-template-nodejs/components/config.js
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright © 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 /**
 	Nodejs Template Project
   @module: config.js

--- a/templates/api-template-nodejs/components/error-handler.js
+++ b/templates/api-template-nodejs/components/error-handler.js
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright © 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 /**
 	Nodejs Template Project
   @module: error-handler.js
@@ -36,25 +20,25 @@ module.exports = () => {
                 message: errorMessage.toString()
             }
         ),
-        throwUnauthorizedError: (errorMessage) => ( 
+        throwUnauthorizedError: (errorMessage) => (
             {
                 errorType: "Unauthorized",
                 message: errorMessage.toString()
             }
         ),
-        throwNotFoundError: (errorMessage) => ( 
+        throwNotFoundError: (errorMessage) => (
             {
                 errorType: "NotFound",
                 message: errorMessage.toString()
             }
         ),
-        throwInternalServerError: (errorMessage) => ( 
+        throwInternalServerError: (errorMessage) => (
             {
                 errorType: "InternalServerError",
                 message: errorMessage.toString()
             }
         )
     };
-    
+
     return errorObj;
 };

--- a/templates/api-template-nodejs/components/logger.js
+++ b/templates/api-template-nodejs/components/logger.js
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright © 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 /**
     Nodejs Template Project
     @module: logger.js

--- a/templates/api-template-nodejs/components/response.js
+++ b/templates/api-template-nodejs/components/response.js
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright © 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 /**
 	Nodejs Template Project
   @module: response.js

--- a/templates/api-template-nodejs/index.js
+++ b/templates/api-template-nodejs/index.js
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright © 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 /**
 Nodejs Template Project
 @author:

--- a/templates/api-template-nodejs/test/test.js
+++ b/templates/api-template-nodejs/test/test.js
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright © 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 const assert = require('chai').assert;
 const index = require('../index');
 

--- a/templates/lambda-template-java/src/main/java/com/slf/exceptions/BadRequestException.java
+++ b/templates/lambda-template-java/src/main/java/com/slf/exceptions/BadRequestException.java
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright 2017 T-Mobile USA, Inc.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 package com.slf.exceptions;
 
 public class BadRequestException extends BaseException {

--- a/templates/lambda-template-java/src/main/java/com/slf/exceptions/BaseException.java
+++ b/templates/lambda-template-java/src/main/java/com/slf/exceptions/BaseException.java
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright 2017 T-Mobile USA, Inc.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 package com.slf.exceptions;
 
 import com.slf.model.ErrorInfo;
@@ -24,16 +8,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class BaseException extends RuntimeException {
 
 	private ErrorInfo err = new ErrorInfo();
-	
+
 	public BaseException(String errortype, String message) {
 		err.setErrorType(errortype);
 		err.setMessage(message);
 	}
-	
+
 	@Override
     public String getMessage(){
 		String jsonInString = null;
-		
+
 		try {
 			ObjectMapper mapper = new ObjectMapper();
 			jsonInString = mapper.writeValueAsString(err);
@@ -41,8 +25,8 @@ public class BaseException extends RuntimeException {
 		} catch (JsonProcessingException ex) {
 			throw new InternalServerErrorException("Parsor Error occured.");
 		}
-		
-		return jsonInString; 
+
+		return jsonInString;
 	}
-	
+
 }

--- a/templates/lambda-template-java/src/main/java/com/slf/exceptions/InternalServerErrorException.java
+++ b/templates/lambda-template-java/src/main/java/com/slf/exceptions/InternalServerErrorException.java
@@ -1,23 +1,7 @@
-// =========================================================================
-// Copyright 2017 T-Mobile USA, Inc.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 package com.slf.exceptions;
 
 public class InternalServerErrorException extends BaseException {
-	
+
 	public InternalServerErrorException(String message) {
 		super("InternalServerError", message);
 	}

--- a/templates/lambda-template-java/src/main/java/com/slf/exceptions/NotFoundException.java
+++ b/templates/lambda-template-java/src/main/java/com/slf/exceptions/NotFoundException.java
@@ -1,23 +1,7 @@
-// =========================================================================
-// Copyright 2017 T-Mobile USA, Inc.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 package com.slf.exceptions;
 
 public class NotFoundException extends BaseException {
-	
+
 	public NotFoundException(String message) {
 		super("NotFound", message);
 	}

--- a/templates/lambda-template-java/src/main/java/com/slf/model/ErrorInfo.java
+++ b/templates/lambda-template-java/src/main/java/com/slf/model/ErrorInfo.java
@@ -1,38 +1,22 @@
-// =========================================================================
-// Copyright 2017 T-Mobile USA, Inc.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 package com.slf.model;
 
 public class ErrorInfo {
-	
+
 	private String errorType;
 	private String message;
-	
+
 	public ErrorInfo(String errorType, String message) {
 		this.errorType = errorType;
 		this.message = message;
 	}
-	
+
 	public ErrorInfo(String message) {
 		this.message = message;
 	}
 
 	public ErrorInfo() {
 	}
-	
+
 	public String getErrorType() {
 		return errorType;
 	}

--- a/templates/lambda-template-java/src/main/java/com/slf/model/Request.java
+++ b/templates/lambda-template-java/src/main/java/com/slf/model/Request.java
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright 2017 T-Mobile USA, Inc.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 package com.slf.model;
 
 public class Request {

--- a/templates/lambda-template-java/src/main/java/com/slf/model/Response.java
+++ b/templates/lambda-template-java/src/main/java/com/slf/model/Response.java
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright 2017 T-Mobile USA, Inc.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 package com.slf.model;
 
 import java.util.Map;

--- a/templates/lambda-template-java/src/main/java/com/slf/services/Handler.java
+++ b/templates/lambda-template-java/src/main/java/com/slf/services/Handler.java
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 package com.slf.services;
 
 import java.util.HashMap;
@@ -30,7 +14,7 @@ import com.slf.util.EnvironmentConfig;
 	This is a java template for developing and deploying functions. The template is based on the
 	predefined interfaces provided by the AWS Lambda Java core library to create your function handler.
 
-	@Author: T-Mobile
+	@Author:
 	@version: 1.0
 	@Date:
 
@@ -53,7 +37,7 @@ public class Handler implements RequestHandler<Request, Response> {
 				throw new InternalServerErrorException("Could not load env properties file: "+ex.getMessage());
 		}
 		*/
-		
+
 		/*
 		logger.trace("Finer-grained informational events than the DEBUG ");
 		logger.info("Interesting runtime events (Eg. connection established, data fetched etc.)");

--- a/templates/lambda-template-java/src/main/java/com/slf/util/EnvironmentConfig.java
+++ b/templates/lambda-template-java/src/main/java/com/slf/util/EnvironmentConfig.java
@@ -17,7 +17,7 @@ import org.apache.log4j.Logger;
  * EnvironmentConfig configObject = new EnvironmentConfig(context);
  * String config_value = configObject.getConfig("config_key");
 
- * @author DSundar3
+ * @author
  * @version
  *
  */

--- a/templates/lambda-template-java/src/main/java/com/slf/util/EnvironmentConfig.java
+++ b/templates/lambda-template-java/src/main/java/com/slf/util/EnvironmentConfig.java
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright 2017 T-Mobile USA, Inc.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 package com.slf.util;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -26,41 +10,41 @@ import org.apache.log4j.Logger;
 
 
 /**
- * The environment configuration reader class. Environment configurations can be specified in a properties file. 
- * Each environment will be having a separate properties file. For ex. dev.properties for 'DEV' 
- * 
+ * The environment configuration reader class. Environment configurations can be specified in a properties file.
+ * Each environment will be having a separate properties file. For ex. dev.properties for 'DEV'
+ *
  * Usage:
  * EnvironmentConfig configObject = new EnvironmentConfig(context);
  * String config_value = configObject.getConfig("config_key");
 
  * @author DSundar3
- * @version 
+ * @version
  *
  */
 public class EnvironmentConfig {
-	
+
 	static final Logger logger = Logger.getLogger(EnvironmentConfig.class);
-	
+
 	private static Properties props = new Properties();
-	private static String stage = null; 
+	private static String stage = null;
 
 	public EnvironmentConfig (Context context) throws Exception {
 		String fnName = context.getFunctionName();
-		
+
 		if(null != fnName) {
 			int lastIndx = fnName.lastIndexOf("-");
 			stage = fnName.substring(lastIndx+1);
 		}
-		
+
 		if(stage.isEmpty()) {
 			throw new BadRequestException("Invalid Stage. Can't load ENV configurations");
 		}
-		
+
 		String configFile = "/"+stage+".properties";
 		logger.info("Loading configuration file for env..:"+configFile);
 		props.load(this.getClass().getResourceAsStream(configFile));
 	}
-	
+
 	public String getConfig(String key) {
 		if(props != null) {
 			String value = props.getProperty(key);
@@ -68,7 +52,7 @@ public class EnvironmentConfig {
 		}
 		return null;
 	}
-	
+
 	@Override
 	public String toString() {
 		return "Loaded config for "+stage;

--- a/templates/lambda-template-java/src/test/java/com/slf/services/HandlerTest.java
+++ b/templates/lambda-template-java/src/test/java/com/slf/services/HandlerTest.java
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 package com.slf.services;
 
 import static org.hamcrest.CoreMatchers.containsString;

--- a/templates/lambda-template-nodejs/components/config.js
+++ b/templates/lambda-template-nodejs/components/config.js
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright © 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 /**
 	Nodejs Template Project
   @module: config.js

--- a/templates/lambda-template-nodejs/components/error-handler.js
+++ b/templates/lambda-template-nodejs/components/error-handler.js
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright © 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 /**
 	Nodejs Template Project
   @module: error-handler.js

--- a/templates/lambda-template-nodejs/components/logger.js
+++ b/templates/lambda-template-nodejs/components/logger.js
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright © 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 /**
     Nodejs Template Project
     @module: logger.js

--- a/templates/lambda-template-nodejs/components/response.js
+++ b/templates/lambda-template-nodejs/components/response.js
@@ -1,23 +1,7 @@
-// =========================================================================
-// Copyright © 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 /**
 	Nodejs Template Project
   @module: response.js
-  @description: Defines reponse object
+  @description: Defines response object
 	@author:
 	@version: 1.0
 **/

--- a/templates/lambda-template-nodejs/index.js
+++ b/templates/lambda-template-nodejs/index.js
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright © 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 /**
 	Nodejs Lambda Template Project
 	@Author:

--- a/templates/lambda-template-nodejs/test/test.js
+++ b/templates/lambda-template-nodejs/test/test.js
@@ -1,19 +1,3 @@
-// =========================================================================
-// Copyright © 2017 T-Mobile USA, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =========================================================================
-
 const assert = require('chai').assert;
 
 describe('Sample', () => {

--- a/templates/lambda-template-python/components/__init__.py
+++ b/templates/lambda-template-python/components/__init__.py
@@ -1,16 +1,3 @@
-# =========================================================================
-# Copyright 2017 T-Mobile USA, Inc.
-# 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =========================================================================
-
+# Python Template Project
+# @Author:
+# @version: 1.0

--- a/templates/lambda-template-python/components/config.py
+++ b/templates/lambda-template-python/components/config.py
@@ -1,19 +1,3 @@
-# =========================================================================
-# Copyright 2017 T-Mobile USA, Inc.
-# 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =========================================================================
-
 # Python Template Project
 # @Author:
 # @version: 1.0

--- a/templates/lambda-template-python/components/logger.py
+++ b/templates/lambda-template-python/components/logger.py
@@ -1,19 +1,3 @@
-# =========================================================================
-# Copyright 2017 T-Mobile USA, Inc.
-# 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =========================================================================
-
 '''
     Python Logging Component
     @module: logger.py

--- a/templates/lambda-template-python/components/logger.py
+++ b/templates/lambda-template-python/components/logger.py
@@ -1,10 +1,8 @@
-'''
-    Python Logging Component
-    @module: logger.py
-    @description: a simple logging module for python
-    @author:
-    @version: 1.0
-'''
+# Python Logging Component
+# @module: logger.py
+# @description: a simple logging module for python
+# @author:
+# @version: 1.0
 
 from datetime import datetime
 import os

--- a/templates/lambda-template-python/index.py
+++ b/templates/lambda-template-python/index.py
@@ -1,19 +1,3 @@
-# =========================================================================
-# Copyright 2017 T-Mobile USA, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =========================================================================
-
 #   Python Template Project
 #   @Author:
 #   @version: 1.0

--- a/templates/lambda-template-python/test/__init__.py
+++ b/templates/lambda-template-python/test/__init__.py
@@ -1,16 +1,4 @@
-# =========================================================================
-# Copyright 2017 T-Mobile USA, Inc.
-# 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =========================================================================
+# Python Template Project
+# @Author:
+# @version: 1.0
 

--- a/templates/lambda-template-python/test/test_hello.py
+++ b/templates/lambda-template-python/test/test_hello.py
@@ -1,19 +1,3 @@
-# =========================================================================
-# Copyright 2017 T-Mobile USA, Inc.
-# 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =========================================================================
-
 # Test lambda function
 def test():
     message = "test pass"


### PR DESCRIPTION
### Description of the Change

Remove copyright headers from template files

### Benefits

T-Mobile doesn't own user services.

### Possible Drawbacks

N/A
