### PR TITLE
:bug: Fixing issue of events(all) of s3

### DIFF
--- a/builds/jazz-build-module/aws-lambda-events-module.groovy
+++ b/builds/jazz-build-module/aws-lambda-events-module.groovy
@@ -187,11 +187,13 @@ def getLambdaEvents(existing_notifications, events){
   // Removing the existing events from the new event list
   for (item in events) {
     cleanupIndex++
-    if (((item.contains("ObjectCreated") || item.contains("ObjectRemoved")) &&
-      (existing_events.contains("s3:ObjectCreated:*") || existing_events.contains("s3:ObjectRemoved:*"))) || (existing_events.contains(item))) {
-      new_events[cleanupIndex] = null
+    if ((item.contains("ObjectCreated") && existing_events.contains("s3:ObjectCreated:*")) ||
+       (item.contains("ObjectRemoved") && existing_events.contains("s3:ObjectRemoved:*")) ||
+       existing_events.contains(item) ) {
+         new_events[cleanupIndex] = null
     }
   }
+
   new_events.removeAll([null])
   def events_list = []
   if (new_events.size() > 0 && new_events != null) {


### PR DESCRIPTION
### Requirements

This PR will fix the issue of not adding the trigger for the existing bucket with objectcreated:* or objectRemoved:*  events and the new trigger is any of it.

### Description of the Change
Modified in aws lambda event module

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
