### PR TITLE
Use patched versions of `jackson-databind`

### DIFF
--- a/templates/api-template-java/pom.xml
+++ b/templates/api-template-java/pom.xml
@@ -13,16 +13,16 @@
       <artifactId>aws-lambda-java-core</artifactId>
       <version>1.1.0</version>
     </dependency>
-	<dependency>
-		<groupId>com.fasterxml.jackson.core</groupId>
-		<artifactId>jackson-databind</artifactId>
-		<version>2.6.3</version>
-	</dependency>
-	<dependency>
-	    <groupId>com.amazonaws</groupId>
-	    <artifactId>aws-lambda-java-log4j</artifactId>
-	    <version>1.0.0</version>
-	</dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>[2.8.11.1,)</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-lambda-java-log4j</artifactId>
+      <version>1.0.0</version>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -34,13 +34,13 @@
   <build>
     <plugins>
       <!--
-        Using the Apache Maven Shade plugin to package the jar
+          Using the Apache Maven Shade plugin to package the jar
 
-        "This plugin provides the capability to package the artifact
-        in an uber-jar, including its dependencies and to shade - i.e. rename -
-        the packages of some of the dependencies."
+          "This plugin provides the capability to package the artifact
+          in an uber-jar, including its dependencies and to shade - i.e. rename -
+          the packages of some of the dependencies."
 
-        Link: https://maven.apache.org/plugins/maven-shade-plugin/
+          Link: https://maven.apache.org/plugins/maven-shade-plugin/
       -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/templates/lambda-template-java/pom.xml
+++ b/templates/lambda-template-java/pom.xml
@@ -14,15 +14,15 @@
       <version>1.1.0</version>
     </dependency>
     <dependency>
-		<groupId>com.fasterxml.jackson.core</groupId>
-		<artifactId>jackson-databind</artifactId>
-		<version>2.6.3</version>
-	</dependency>
-	<dependency>
-	    <groupId>com.amazonaws</groupId>
-	    <artifactId>aws-lambda-java-log4j</artifactId>
-	    <version>1.0.0</version>
-	</dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>[2.8.11.1,)</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-lambda-java-log4j</artifactId>
+      <version>1.0.0</version>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -34,13 +34,13 @@
   <build>
     <plugins>
       <!--
-        Using the Apache Maven Shade plugin to package the jar
+          Using the Apache Maven Shade plugin to package the jar
 
-        "This plugin provides the capability to package the artifact
-        in an uber-jar, including its dependencies and to shade - i.e. rename -
-        the packages of some of the dependencies."
+          "This plugin provides the capability to package the artifact
+          in an uber-jar, including its dependencies and to shade - i.e. rename -
+          the packages of some of the dependencies."
 
-        Link: https://maven.apache.org/plugins/maven-shade-plugin/
+          Link: https://maven.apache.org/plugins/maven-shade-plugin/
       -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
There are multiple CVEs open against the version of `jackson-databind` we're defaulting to in our templates, so fix that.