### PR TITLE
Admin Unit Tests

### DIFF
--- a/core/jazz_admin/config/test-config.json
+++ b/core/jazz_admin/config/test-config.json
@@ -1,0 +1,13 @@
+{
+  "ADMIN_ID": "test@test.com",
+  "BASE_URL": "scm_base_url",
+  "BITBUCKET": {
+    "USERNAME": "bb_username",
+    "PASSWORD": "bb_password",
+    "CONFIG_FILE_PATH": "/projects/SLF/repos/jazz-build-module/raw/jazz-installer-vars.json"
+  },
+  "GITLAB": {
+    "CONFIG_FILE_PATH": "/slf/jazz-build-module/raw/master/jazz-installer-vars.json",
+    "PRIVATE_TOKEN": "private-token"
+  }
+}

--- a/core/jazz_admin/index.js
+++ b/core/jazz_admin/index.js
@@ -42,7 +42,7 @@ function handler(event, context, cb) {
       if (event.principalId != config.ADMIN_ID) {
         return cb(JSON.stringify(errorHandler.throwUnauthorizedError("This user is not authorized to access this service.")));
       }
-      getInstallerVarsJSON(config).then((data) => {
+      exportable.getInstallerVarsJSON(config).then((data) => {
         apiResponseObj.config = data;
         return cb(null, responseObj(apiResponseObj, event.body));
       }).catch((error) => {
@@ -56,8 +56,8 @@ function handler(event, context, cb) {
     logger.error(JSON.stringify(error));
     cb(JSON.stringify(errorHandler.throwInternalServerError("Unknown Error")));
   }
-
 }
+
 function buildRequestOption(config) {
   if (config.SCM_TYPE === "gitlab") {
     return {
@@ -103,8 +103,10 @@ function getInstallerVarsJSON(config) {
   });
 }
 
-module.exports = {
+const exportable = {
   handler,
   getInstallerVarsJSON,
   buildRequestOption
-};
+}
+
+module.exports = exportable;

--- a/core/jazz_admin/package.json
+++ b/core/jazz_admin/package.json
@@ -9,10 +9,13 @@
     "test": "mocha"
   },
   "dependencies": {
+    "nyc": "^13.1.0",
     "request": "*"
   },
   "devDependencies": {
+    "aws-lambda-mock-context": "^3.2.1",
+    "chai": "^3.5.0",
     "mocha": "^v3.0.0",
-    "chai": "^3.5.0"
+    "sinon": "^7.1.0"
   }
 }

--- a/core/jazz_admin/package.json
+++ b/core/jazz_admin/package.json
@@ -9,7 +9,6 @@
     "test": "mocha"
   },
   "dependencies": {
-    "nyc": "^13.1.0",
     "request": "*"
   },
   "devDependencies": {

--- a/core/jazz_admin/test/test.js
+++ b/core/jazz_admin/test/test.js
@@ -25,7 +25,6 @@ const configObj = require('../components/config.js');
 describe('jazz_admin', function () {
 
   beforeEach(function () {
-    spy = sinon.spy();
     event = {
       "stage": "test",
       "method": "GET",
@@ -78,7 +77,7 @@ describe('jazz_admin', function () {
 
     it("should indicate error while making request to gitlab repo", () => {
       config.SCM_TYPE = "gitlab";
-      var responseObj = {
+      let responseObj = {
         statusCode: 401,
         body: {
           data: {},
@@ -91,14 +90,14 @@ describe('jazz_admin', function () {
       index.getInstallerVarsJSON(config)
         .catch(error => {
           expect(error).to.include('Unauthorized');
+          sinon.assert.calledOnce(reqStub);
+          reqStub.restore();
         });
-      sinon.assert.calledOnce(reqStub);
-      reqStub.restore();
     });
 
     it("should indicate error while making request to bitbucket repo", () => {
       config.SCM_TYPE = "gitlab";
-      var responseObj = {
+      let responseObj = {
         statusCode: 401,
         body: {
           data: {},
@@ -111,13 +110,13 @@ describe('jazz_admin', function () {
       index.getInstallerVarsJSON(config)
         .catch(error => {
           expect(error).to.include('Unauthorized');
+          sinon.assert.calledOnce(reqStub);
+          reqStub.restore();
         });
-      sinon.assert.calledOnce(reqStub);
-      reqStub.restore();
     });
 
     it("should successfully get installer variables on request", () => {
-      var responseObj = {
+      let responseObj = {
         statusCode: 200,
         body: "{\"CRED_ID\": \"jazzaws\", \"INST_PRE\": \"jazzsw\"}"
       };
@@ -127,16 +126,16 @@ describe('jazz_admin', function () {
       index.getInstallerVarsJSON(config)
         .then(res => {
           expect(res).to.deep.eq(JSON.parse(responseObj.body));
+          sinon.assert.calledOnce(reqStub);
+          reqStub.restore();
         });
-      sinon.assert.calledOnce(reqStub);
-      reqStub.restore();
     });
   });
 
   describe('handler', () => {
 
     it("should indicate internal server error when admin file is not fetched", () => {
-      var responseObj = {
+      let responseObj = {
         statusCode: 401,
         body: {
           data: {},
@@ -147,14 +146,13 @@ describe('jazz_admin', function () {
       message = '{"errorType":"InternalServerError","message":"Failed to load config file."}';
       index.handler(event, context, (err, res) => {
         expect(err).to.include(message);
+        sinon.assert.calledOnce(getInstallerVarsJSON);
+        getInstallerVarsJSON.restore();
       });
-
-      sinon.assert.calledOnce(getInstallerVarsJSON);
-      getInstallerVarsJSON.restore();
     });
 
     it("should return admin file as response on success", () => {
-      var responseObj = {
+      let responseObj = {
         body: {
           "CRED_ID": "jazzaws", 
           "INST_PRE": "jazzsw"

--- a/core/jazz_admin/test/test.js
+++ b/core/jazz_admin/test/test.js
@@ -1,11 +1,171 @@
-const assert = require('chai').assert;
+// =========================================================================
+// Copyright © 2017 T-Mobile USA, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =========================================================================
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const request = require('request');
+
 const index = require('../index');
+const awsContext = require('aws-lambda-mock-context');
+const configObj = require('../components/config.js');
 
-describe('Sample', function() {
-  it('tests handler', function(done) {
+describe('jazz_admin', function () {
 
-    // Add your test cases here.
-    assert(true);
-    done();
+  beforeEach(function () {
+    spy = sinon.spy();
+    event = {
+      "stage": "test",
+      "method": "GET",
+      "principalId" : "test@test.com",
+      "body":{}
+    };
+    callback = (err, responseObj) => {
+      if (err) {
+        return err;
+      } else {
+        return JSON.stringify(responseObj);
+      }
+    };
+    err = {
+      "errorType": "foo",
+      "message": "bar"
+    };
+    callbackObj = {
+      "callback": callback
+    };
+    config = configObj.getConfig(event, context);
+    context = awsContext();
+  });
+
+  describe('validation tests', () => {
+
+   it("should state that POST method is not supported", function () {
+      event.method = "POST";
+      index.handler(event, context, (error, data) => {
+        expect(error).to.include('{"errorType":"BadRequest","message":"The requested method is not supported"}');
+      });
+    });
+  
+    it("should state the user isn't authorized if no principalId is given", function () {
+      event.principalId = "";
+      index.handler(event, context, (error, data) => {
+        expect(error).to.include('{"errorType":"Unauthorized","message":"User is not authorized to access this service|Authorization Incomplete"}');
+      });
+    });
+
+    it("should state the user isn't authorized if principalId given is not same as admin id", function () {
+      event.principalId = "foo@foo.com";
+      index.handler(event, context, (error, data) => {
+        expect(error).to.include('{"errorType":"Unauthorized","message":"This user is not authorized to access this service.');
+      });
+    });
+  });
+
+  describe('getInstallerVarsJSON', () => {
+
+    it("should indicate error while making request to gitlab repo", () => {
+      config.SCM_TYPE = "gitlab";
+      var responseObj = {
+        statusCode: 401,
+        body: {
+          data: {},
+          message: "Unauthorized"
+        }
+      };
+      reqStub = sinon.stub(request, "Request").callsFake((obj) => {
+        return obj.callback(null, responseObj, responseObj.body)
+      });
+      index.getInstallerVarsJSON(config)
+        .catch(error => {
+          expect(error).to.include('Unauthorized');
+        });
+      sinon.assert.calledOnce(reqStub);
+      reqStub.restore();
+    });
+
+    it("should indicate error while making request to bitbucket repo", () => {
+      config.SCM_TYPE = "gitlab";
+      var responseObj = {
+        statusCode: 401,
+        body: {
+          data: {},
+          message: "Unauthorized"
+        }
+      };
+      reqStub = sinon.stub(request, "Request").callsFake((obj) => {
+        return obj.callback(null, responseObj, responseObj.body)
+      });
+      index.getInstallerVarsJSON(config)
+        .catch(error => {
+          expect(error).to.include('Unauthorized');
+        });
+      sinon.assert.calledOnce(reqStub);
+      reqStub.restore();
+    });
+
+    it("should successfully get installer variables on request", () => {
+      var responseObj = {
+        statusCode: 200,
+        body: "{\"CRED_ID\": \"jazzaws\", \"INST_PRE\": \"jazzsw\"}"
+      };
+      reqStub = sinon.stub(request, "Request").callsFake((obj) => {
+        return obj.callback(null, responseObj, responseObj.body)
+      });
+      index.getInstallerVarsJSON(config)
+        .then(res => {
+          expect(res).to.deep.eq(JSON.parse(responseObj.body));
+        });
+      sinon.assert.calledOnce(reqStub);
+      reqStub.restore();
+    });
+  });
+
+  describe('handler', () => {
+
+    it("should indicate internal server error when admin file is not fetched", () => {
+      var responseObj = {
+        statusCode: 401,
+        body: {
+          data: {},
+          message: "Unauthorized"
+        }
+      };
+      const getInstallerVarsJSON = sinon.stub(index, "getInstallerVarsJSON").rejects(responseObj.body.message)
+      message = '{"errorType":"InternalServerError","message":"Failed to load config file."}';
+      index.handler(event, context, (err, res) => {
+        expect(err).to.include(message);
+      });
+
+      sinon.assert.calledOnce(getInstallerVarsJSON);
+      getInstallerVarsJSON.restore();
+    });
+
+    it("should return admin file as response on success", () => {
+      var responseObj = {
+        body: {
+          "CRED_ID": "jazzaws", 
+          "INST_PRE": "jazzsw"
+        }
+      };
+      const getInstallerVarsJSON = sinon.stub(index, "getInstallerVarsJSON").resolves(responseObj.body);
+      index.handler(event, context, (err, res) => { 
+        expect(res.data.config).to.deep.eq(responseObj.body);
+        sinon.assert.calledOnce(getInstallerVarsJSON);
+        getInstallerVarsJSON.restore();
+      });
+    });
   });
 });


### PR DESCRIPTION
Requirements
adding unit tests to admin api

Description of the Change
added unit tests to the jazz_admin service module with 90% coverage

Benefits
the module was missing unit tests.

Possible Drawbacks
Some minor changes were made to the jazz_admin module for enabling the unit tests. This would need to be tested after deploying.

Applicable Issues