### PR TITLE
Version 3.2.0 shade plugin appears to be more error tolerant.

### DIFF
--- a/templates/api-template-java/pom.xml
+++ b/templates/api-template-java/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.2.0</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
         </configuration>

--- a/templates/api-template-java/src/main/java/com/slf/services/Handler.java
+++ b/templates/api-template-java/src/main/java/com/slf/services/Handler.java
@@ -1,6 +1,6 @@
 package com.slf.services;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import org.apache.log4j.Logger;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
@@ -39,7 +39,7 @@ public class Handler implements RequestHandler<Request, Response> {
 		}
 		*/
 
-		HashMap<String, String> data = new HashMap<String, String>();
+		LinkedHashMap<String, String> data = new LinkedHashMap<String, String>();
 		if ((input == null) || (input.getMethod() == null)) {
 			data.put("key", "Default Value");
 		} else {

--- a/templates/lambda-template-java/pom.xml
+++ b/templates/lambda-template-java/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.2.0</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
         </configuration>


### PR DESCRIPTION


### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change


This is an update to the poms for the lambda and api templates.

if one were to attempt to relocate or hide classes that do not exist for example
```xml
                            <relocations>
                                <relocation>
                                    <pattern>org.codehaus.plexus.util</pattern>
                                    <shadedPattern>org.shaded.plexus.util</shadedPattern>
                                    <excludes>
                                        <exclude>org.codehaus.plexus.util.xml.Xpp3Dom</exclude>
                                        <exclude>org.codehaus.plexus.util.xml.pull.*</exclude>
                                    </excludes>
                                </relocation>
                            </relocations>
```
2.3.0 will error out with
 `Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:2.3:shade (default) on project api-java-template: Error creating shaded jar: null: IllegalArgumentException -> [Help 1]`
3.2.0 moves along i.e. the package stage completes



### Benefits

Package phase will not break when artifacts are not found. it is also the latest version.

### Possible Drawbacks

maybe you do want to die screaming

### Applicable Issues

N/A
