### PR TITLE
Manual deployment scripts - Work In Progress

### DIFF
--- a/builds/jenkins-build-pack-lambda/Jenkinsfile
+++ b/builds/jenkins-build-pack-lambda/Jenkinsfile
@@ -503,9 +503,20 @@ def buildLambda(String runtime) {
 		"""
 	} else if (runtime.indexOf("go") > -1 ){
     //get all dependencies
-    sh "dep ensure"
-    //Build command 
-    sh "env GOOS=linux GOARCH=amd64 go build -o main main.go"
+    
+    /**
+    Created for testing the deployment of Golang lambda function
+    Not a production ready or testable code.
+    **/
+    sh "go env"
+    sh "pwd"
+    sh "mkdir -p /var/lib/jenkins/workspace/build-pack-lambda/src"
+    sh "rsync -a --exclude='.*' /var/lib/jenkins/workspace/build-pack-lambda/develop_lambdatest-go/* /var/lib/jenkins/workspace/build-pack-lambda/src/lambda-template-go"
+    withEnv(['GOPATH=/var/lib/jenkins/workspace/build-pack-lambda']) {
+      sh "cd /var/lib/jenkins/workspace/build-pack-lambda/src/lambda-template-go && dep ensure"
+      sh "env GOOS=linux GOARCH=amd64 go build -o main $GOPATH/src/lambda-template-go/main.go"
+    }
+    sh "pwd"
   }
 }
 


### PR DESCRIPTION
### Requirements

Implementing golang support in Jazz. 

### Description of the Change

Go has a quite unique concept of work space. Work space is the folder structure where $GOPATH points.
Inside $GOPATH there will be three directories named src,bin,pkg.we need to create our project inside src folder with a unique namespace. For Poc purpose  I have created some scripts in build pack lambda, which will deploy only for selected service.

Current workspace for building lamda functions is /var/lib/jenkins/workspace/build-pack-lambda and for api's  is /var/lib/jenkins/workspace/build-pack-api, where we can't build golang application under these workspaces.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
