### PR TITLE
Resolved the GET admin config API issue by renaming the private token placeholder

### DIFF
--- a/core/jazz_admin/config/dev-config.json
+++ b/core/jazz_admin/config/dev-config.json
@@ -9,6 +9,6 @@
   },
   "GITLAB": {
     "CONFIG_FILE_PATH": "/slf/jazz-build-module/raw/master/jazz-installer-vars.json",
-    "PRIVATE_TOKEN": "{private-token}"
+    "PRIVATE_TOKEN": "{private_token}"
   }
 }

--- a/core/jazz_admin/config/prod-config.json
+++ b/core/jazz_admin/config/prod-config.json
@@ -9,6 +9,6 @@
   },
   "GITLAB": {
     "CONFIG_FILE_PATH": "/slf/jazz-build-module/raw/master/jazz-installer-vars.json",
-    "PRIVATE_TOKEN": "{private-token}"
+    "PRIVATE_TOKEN": "{private_token}"
   }
 }

--- a/core/jazz_admin/config/stg-config.json
+++ b/core/jazz_admin/config/stg-config.json
@@ -9,6 +9,6 @@
   },
   "GITLAB": {
     "CONFIG_FILE_PATH": "/slf/jazz-build-module/raw/master/jazz-installer-vars.json",
-    "PRIVATE_TOKEN": "{private-token}"
+    "PRIVATE_TOKEN": "{private_token}"
   }
 }


### PR DESCRIPTION
Resolved the GET admin config API issue by renaming the private token placeholder to match it with the Jenkins job variable used in `build-pack-api` pipeline.

### Description of the Change

Installed Jazz on the community AMI `chef-highperf-centos7-201711290007` on a `t2.large` EC2 instance.

Command used to install is `sudo curl -L https://raw.githubusercontent.com/tmobile/jazz-installer/master/centos7-provision.sh | sh -s -- -ib master && cd jazz-installer && sh Installer.sh -b master`

Used scenario 3

Installation went success and everything works fine. But when i open admin page page gets stuck. Saw a console error

```
polyfills.a7203ed2c3792ed19849.bundle.js:1 
TypeError: Cannot convert undefined or null to object
```

![jazz admin error](https://user-images.githubusercontent.com/18282708/49218001-3e25c580-f3f5-11e8-866c-d5742f239191.png)

When we analysed the issue, we found that the response object of the API `jazz/admin/config` was empty. The root cause was the private token which is used to get the configuration from `
jazz-build-module` repository was not set properly. This value didn't get updated properly because of the mismatch of the place holder used in config and build job.

In config it is `private-token` but in build job it is trying to replace with `private_token`.

### Benefits

The GET admin config API went success, and because of it the admin page loaded properly.

![after-resolution](https://user-images.githubusercontent.com/18282708/49218009-454cd380-f3f5-11e8-96d4-b2a48f8b08a5.png)

### Possible Drawbacks

NA

### Applicable Issues

https://github.com/tmobile/jazz-installer/issues/399


