### PR TITLE
Update label for runtime

### DIFF
--- a/core/jazz_ui/src/app/secondary-components/create-service/internal/create-service.component.html
+++ b/core/jazz_ui/src/app/secondary-components/create-service/internal/create-service.component.html
@@ -82,7 +82,7 @@
                         <section class="col-lg-3 col-md-3 pad-left0">
                             <div class="radio-container">
                                 <input type="radio" class='test-focus' name="runtime" id="nodejs" [value]="nodejs" [checked]="runtime == 'nodejs'" (click)="onSelectionChange('nodejs')">
-                                <label for="nodejs"><span class='outer'></span><span class="background"></span>Nodejs (6.10)</label>
+                                <label for="nodejs"><span class='outer'></span><span class="background"></span>Nodejs (8.10)</label>
                             </div>
                         </section>
                         <section class="col-lg-3 col-md-3 pad-left0">

--- a/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.html
+++ b/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.html
@@ -75,7 +75,7 @@
                         <section class="col-lg-3 col-md-3 pad-left0">
                             <div class="radio-container">
                                 <input type="radio" class='test-focus' name="runtime" id="nodejs" [value]="nodejs" [checked]="runtime == 'nodejs'" (click)="onSelectionChange('nodejs')">
-                                <label for="nodejs"><span class='outer'></span><span class="background"></span>Nodejs (6.10)</label>
+                                <label for="nodejs"><span class='outer'></span><span class="background"></span>Nodejs (8.10)</label>
                             </div>
                         </section>
                         <section class="col-lg-3 col-md-3 pad-left0">


### PR DESCRIPTION
### Description of the Change

Runtime for NodeJS incorrectly shows as 6.1 while the build and execution runtime for Jazz services is Nodejs 8.1

### Benefits
WYSIWYG

### Possible Drawbacks

None

