### PR TITLE
Create a dedicated IAM role for Jazz core services

### DIFF
--- a/builds/delete-serverless-service-build-pack/Jenkinsfile
+++ b/builds/delete-serverless-service-build-pack/Jenkinsfile
@@ -454,13 +454,8 @@ def updateSwaggerConfig() {
 			sh "sed -i -- 's/{domain}/${service_config['domain']}/g' swagger/swagger.json"
 
 			def region = "${configLoader.AWS.REGION}"
-      def role
-      if (service_config['domain'] && service_config['domain'] == "jazz") {
-        role = configLoader.AWS.PLATFORMSERVICES_ROLEID
-      } else {
-        role = configLoader.AWS.USERSERVICES_ROLEID
-      }
-			def roleARN = role.replaceAll("/", "\\\\/")
+      
+			def roleARN = service_config['iamRoleARN'].replaceAll("/", "\\\\/")
 
 			// TODO: the below couple of statements will be replaced with regular expression in very near future;
 			def roleId = roleARN.substring(roleARN.indexOf("::") + 2, roleARN.lastIndexOf(":"))

--- a/builds/delete-serverless-service-build-pack/Jenkinsfile
+++ b/builds/delete-serverless-service-build-pack/Jenkinsfile
@@ -454,7 +454,12 @@ def updateSwaggerConfig() {
 			sh "sed -i -- 's/{domain}/${service_config['domain']}/g' swagger/swagger.json"
 
 			def region = "${configLoader.AWS.REGION}"
-			def role = "${configLoader.AWS.ROLEID}"
+      def role
+      if (service_config['domain'] && service_config['domain'] == "jazz") {
+        role = configLoader.AWS.PLATFORMSERVICES_ROLEID
+      } else {
+        role = configLoader.AWS.USERSERVICES_ROLEID
+      }
 			def roleARN = role.replaceAll("/", "\\\\/")
 
 			// TODO: the below couple of statements will be replaced with regular expression in very near future;

--- a/builds/jazz-build-module/events-module.groovy
+++ b/builds/jazz-build-module/events-module.groovy
@@ -209,7 +209,7 @@ def sendEvent(event_name, event_status, message, moreCxtMap){
 		'branch': g_branch,
 		'runtime': service_metadata['runtime'],
 		'domain': service_metadata['domain'],
-		'iam_role': config_loader.AWS.USERSERVICES_ROLEID,
+		'iam_role': service_metadata['iamRoleARN'],
 		'environment': g_environment,
 		'region': config_loader.AWS.REGION,
 		'message': message

--- a/builds/jazz-build-module/events-module.groovy
+++ b/builds/jazz-build-module/events-module.groovy
@@ -209,7 +209,7 @@ def sendEvent(event_name, event_status, message, moreCxtMap){
 		'branch': g_branch,
 		'runtime': service_metadata['runtime'],
 		'domain': service_metadata['domain'],
-		'iam_role': config_loader.AWS.ROLEID,
+		'iam_role': config_loader.AWS.USERSERVICES_ROLEID,
 		'environment': g_environment,
 		'region': config_loader.AWS.REGION,
 		'message': message

--- a/builds/jazz-build-module/service-configuration-data-loader.groovy
+++ b/builds/jazz-build-module/service-configuration-data-loader.groovy
@@ -44,7 +44,7 @@ def loadServiceConfigurationData() {
         if (fileExists('swagger/swagger.json')) {
             //Swagger SEDs
             echo "Updating the Swagger SEDs"
-            sh "sed -i -- 's/{conf-role}/${role_arn}/g' ./swagger/swagger.json"
+            sh "sed -i -- 's|{conf-role}|${role_arn}|g' ./swagger/swagger.json"
             sh "sed -i -- 's/{conf-region}/${region}/g' ./swagger/swagger.json"
             sh "sed -i -- 's/{conf-accId}/${role_id}/g' ./swagger/swagger.json"
         }

--- a/builds/jenkins-build-pack-api/Jenkinsfile
+++ b/builds/jenkins-build-pack-api/Jenkinsfile
@@ -84,13 +84,6 @@ node() {
 		error "Failed to fetch service metadata from catalog"
 	}
 
-	if (config['domain'] && config['domain'] == "jazz") {
-		config['iamRoleID'] = configLoader.AWS.PLATFORMSERVICES_ROLEID
-	} else {
-		config['iamRoleID'] = configLoader.AWS.USERSERVICES_ROLEID
-	}
-	config['iamRoleARN'] = config['iamRoleID'].replaceAll("/", "\\\\/")
-
 	dir(repo_name)
 	{
 		scmModule.setServiceConfig(config)
@@ -238,7 +231,7 @@ node() {
 
 					writeServerlessFile(config, environment_logical_id)
 					
-					setLambdaExecutionRole(config['iamRoleID']);
+					setLambdaExecutionRole(config['iamRoleARN']);
 
 					echo "serverless deploy......."
 					def envBucketKey = "${env_key}${configLoader.JAZZ.S3_BUCKET_NAME_SUFFIX}"
@@ -532,7 +525,7 @@ def generateSwaggerEnv(env, deploymentNode, apiHostName, config) {
 	// TODO: the below couple of statements will be replaced with regular expression in very near future;
 	def roleId = config['iamRoleARN'].substring(config['iamRoleARN'].indexOf("::") + 2, config['iamRoleARN'].lastIndexOf(":"))
 
-	sh "sed -i -- 's/{conf-role}/${config['iamRoleARN']}/g' ./swagger/swagger.json"
+	sh "sed -i -- 's|{conf-role}|${config['iamRoleARN']}|g' ./swagger/swagger.json"
 	sh "sed -i -- 's/{conf-region}/${configLoader.AWS.REGION}/g' ./swagger/swagger.json"
 	sh "sed -i -- 's/{conf-accId}/${roleId}/g' ./swagger/swagger.json"
 }

--- a/builds/jenkins-build-pack-api/Jenkinsfile
+++ b/builds/jenkins-build-pack-api/Jenkinsfile
@@ -75,11 +75,6 @@ node() {
 
 		if (configObj.service_id) {
 			config = serviceMetadataLoader.loadServiceMetadata(configObj.service_id)
-			if (config['domain'] && config['domain'] == "jazz") {
-		    	config['iamRoleID'] = configLoader.AWS.PLATFORMSERVICES_ROLEID
-		  	} else {
-		    	config['iamRoleID'] = configLoader.AWS.USERSERVICES_ROLEID
-		  	}
 		} else {
 			error "Service Id is not available."
 		}
@@ -88,7 +83,12 @@ node() {
 	if (!config) {
 		error "Failed to fetch service metadata from catalog"
 	}
-	
+
+	if (config['domain'] && config['domain'] == "jazz") {
+		config['iamRoleID'] = configLoader.AWS.PLATFORMSERVICES_ROLEID
+	} else {
+		config['iamRoleID'] = configLoader.AWS.USERSERVICES_ROLEID
+	}
 	config['iamRoleARN'] = config['iamRoleID'].replaceAll("/", "\\\\/")
 
 	dir(repo_name)
@@ -124,10 +124,9 @@ node() {
 		def stackName = "${configLoader.INSTANCE_PREFIX}-${config['domain']}-${config['service']}-${environment_logical_id}"
 
 		def internalAccess = config['require_internal_access']
-		def roleARN = config['iamRoleARN']
 
 		// @TODO: the below statement will be replaced with regular expression in very near future;
-		def roleId = roleARN.substring(roleARN.indexOf("::") + 2, roleARN.lastIndexOf(":"))
+		def roleId = config['iamRoleARN'].substring(config['iamRoleARN'].indexOf("::") + 2, config['iamRoleARN'].lastIndexOf(":"))
 
 		sonarModule.initialize(configLoader, config, branch)
 
@@ -137,7 +136,7 @@ node() {
 			stage('Update Service Template'){
 				echo "Inside Update service template"
 				try {
-					updatePlatformServiceTemplate(config, roleARN, roleId, current_environment, repo_name)
+					updatePlatformServiceTemplate(config, config['iamRoleARN'], roleId, current_environment, repo_name)
 				}
 				catch (error) {
 					error "Error occured while updating service template."
@@ -529,12 +528,11 @@ def generateSwaggerEnv(env, deploymentNode, apiHostName, config) {
 	sh "sed -i -- 's/{envPrefix}/${configLoader.INSTANCE_PREFIX}/g' swagger/swagger.json" // {domain}
 	sh "sed -i -- 's/{envmnt}/${current_environment}/g' swagger/swagger.json" // {environment}
 
-	def roleARN = config['iamRoleARN']
 
 	// TODO: the below couple of statements will be replaced with regular expression in very near future;
-	def roleId = roleARN.substring(roleARN.indexOf("::") + 2, roleARN.lastIndexOf(":"))
+	def roleId = config['iamRoleARN'].substring(config['iamRoleARN'].indexOf("::") + 2, config['iamRoleARN'].lastIndexOf(":"))
 
-	sh "sed -i -- 's/{conf-role}/${roleARN}/g' ./swagger/swagger.json"
+	sh "sed -i -- 's/{conf-role}/${config['iamRoleARN']}/g' ./swagger/swagger.json"
 	sh "sed -i -- 's/{conf-region}/${configLoader.AWS.REGION}/g' ./swagger/swagger.json"
 	sh "sed -i -- 's/{conf-accId}/${roleId}/g' ./swagger/swagger.json"
 }

--- a/builds/jenkins-build-pack-api/Jenkinsfile
+++ b/builds/jenkins-build-pack-api/Jenkinsfile
@@ -21,6 +21,7 @@ import groovy.transform.Field
 @Field def sonarModule
 
 @Field def auth_token = ''
+@Field def config
 @Field def g_svc_admin_cred_ID = 'SVC_ADMIN'
 @Field def g_base_url = ''
 @Field def environment_logical_id = ''
@@ -47,7 +48,6 @@ node() {
 		repo_name = params.domain + "_" + params.service_name
 	}
 
-	def config
 	def domain = params.domain
 
 	stage('Checkout code base') {
@@ -75,6 +75,11 @@ node() {
 
 		if (configObj.service_id) {
 			config = serviceMetadataLoader.loadServiceMetadata(configObj.service_id)
+			if (config['domain'] && config['domain'] == "jazz") {
+		    	config['iamRoleID'] = configLoader.AWS.PLATFORMSERVICES_ROLEID
+		  	} else {
+		    	config['iamRoleID'] = configLoader.AWS.USERSERVICES_ROLEID
+		  	}
 		} else {
 			error "Service Id is not available."
 		}
@@ -83,6 +88,8 @@ node() {
 	if (!config) {
 		error "Failed to fetch service metadata from catalog"
 	}
+	
+	config['iamRoleARN'] = config['iamRoleID'].replaceAll("/", "\\\\/")
 
 	dir(repo_name)
 	{
@@ -117,7 +124,7 @@ node() {
 		def stackName = "${configLoader.INSTANCE_PREFIX}-${config['domain']}-${config['service']}-${environment_logical_id}"
 
 		def internalAccess = config['require_internal_access']
-		def roleARN = configLoader.AWS.ROLEID.replaceAll("/", "\\\\/")
+		def roleARN = config['iamRoleARN']
 
 		// @TODO: the below statement will be replaced with regular expression in very near future;
 		def roleId = roleARN.substring(roleARN.indexOf("::") + 2, roleARN.lastIndexOf(":"))
@@ -231,8 +238,8 @@ node() {
 					echo "Generate deployment env with domain for ${env_key}"
 
 					writeServerlessFile(config, environment_logical_id)
-
-					setLambdaExecutionRole(configLoader.AWS.ROLEID);
+					
+					setLambdaExecutionRole(config['iamRoleID']);
 
 					echo "serverless deploy......."
 					def envBucketKey = "${env_key}${configLoader.JAZZ.S3_BUCKET_NAME_SUFFIX}"
@@ -521,7 +528,8 @@ def generateSwaggerEnv(env, deploymentNode, apiHostName, config) {
 	sh "sed -i -- 's/{domain}/${config['domain']}/g' swagger/swagger.json" // {domain}
 	sh "sed -i -- 's/{envPrefix}/${configLoader.INSTANCE_PREFIX}/g' swagger/swagger.json" // {domain}
 	sh "sed -i -- 's/{envmnt}/${current_environment}/g' swagger/swagger.json" // {environment}
-	def roleARN = configLoader.AWS.ROLEID.replaceAll("/", "\\\\/")
+
+	def roleARN = config['iamRoleARN']
 
 	// TODO: the below couple of statements will be replaced with regular expression in very near future;
 	def roleId = roleARN.substring(roleARN.indexOf("::") + 2, roleARN.lastIndexOf(":"))

--- a/builds/jenkins-build-pack-lambda/Jenkinsfile
+++ b/builds/jenkins-build-pack-lambda/Jenkinsfile
@@ -90,13 +90,6 @@ node() {
     error "Failed to fetch service metadata from catalog"
   }
 
-  if (config['domain'] && config['domain'] == "jazz") {
-    config['iamRoleID'] = configLoader.AWS.PLATFORMSERVICES_ROLEID
-  } else {
-    config['iamRoleID'] = configLoader.AWS.USERSERVICES_ROLEID
-  }
-  config['iamRoleARN'] = config['iamRoleID'].replaceAll("/", "\\\\/")
-
   dir(repo_name) {
     scmModule.setServiceConfig(config)
     def envApi = "${g_base_url}/jazz/environments"

--- a/builds/jenkins-build-pack-lambda/Jenkinsfile
+++ b/builds/jenkins-build-pack-lambda/Jenkinsfile
@@ -81,11 +81,6 @@ node() {
 
     if (configObj.service_id) {
       config = serviceMetadataLoader.loadServiceMetadata(configObj.service_id)
-      if (config['domain'] && config['domain'] == "jazz") {
-          config['iamRoleID'] = configLoader.AWS.PLATFORMSERVICES_ROLEID
-      } else {
-          config['iamRoleID'] = configLoader.AWS.USERSERVICES_ROLEID
-      }
     } else {
       error "Service Id is not available."
     }
@@ -95,6 +90,11 @@ node() {
     error "Failed to fetch service metadata from catalog"
   }
 
+  if (config['domain'] && config['domain'] == "jazz") {
+    config['iamRoleID'] = configLoader.AWS.PLATFORMSERVICES_ROLEID
+  } else {
+    config['iamRoleID'] = configLoader.AWS.USERSERVICES_ROLEID
+  }
   config['iamRoleARN'] = config['iamRoleID'].replaceAll("/", "\\\\/")
 
   dir(repo_name) {
@@ -135,10 +135,9 @@ node() {
   def isEventSchdld = false
   def internalAccess = config['require_internal_access']
   domain = config['domain']
-  def roleARN = config['iamRoleARN']
   
   // @TODO: the below statement will be replaced with regular expression in very near future;
-  def roleId = roleARN.substring(roleARN.indexOf("::") + 2, roleARN.lastIndexOf(":"))
+  def roleId = config['iamRoleARN'].substring(config['iamRoleARN'].indexOf("::") + 2, config['iamRoleARN'].lastIndexOf(":"))
 
   sonarModule.initialize(configLoader, config, branch)
   stackName = "${configLoader.INSTANCE_PREFIX}-${config['domain']}-${config['service']}-${environment_logical_id}"
@@ -163,7 +162,7 @@ node() {
       stage('Update Service Template') {
         echo "Inside Update service template"
         try {
-          updatePlatformServiceTemplate(config, roleARN, roleId, current_environment, repo_name)
+          updatePlatformServiceTemplate(config, config['iamRoleARN'], roleId, current_environment, repo_name)
         } catch (error) {
           error "Error occured while updating service template."
         }

--- a/builds/jenkins-build-pack-lambda/Jenkinsfile
+++ b/builds/jenkins-build-pack-lambda/Jenkinsfile
@@ -23,6 +23,7 @@ import groovy.transform.Field
 @Field def sonarModule
 
 @Field def auth_token = ''
+@Field def config
 @Field def g_base_url = ''
 @Field def g_svc_admin_cred_ID = 'SVC_ADMIN'
 @Field def current_environment = ''
@@ -50,7 +51,6 @@ node() {
     repo_name = params.domain + "_" + params.service_name
   }
 
-  def config
   def domain = params.domain
 
   stage('Checkout code base') {
@@ -81,6 +81,11 @@ node() {
 
     if (configObj.service_id) {
       config = serviceMetadataLoader.loadServiceMetadata(configObj.service_id)
+      if (config['domain'] && config['domain'] == "jazz") {
+          config['iamRoleID'] = configLoader.AWS.PLATFORMSERVICES_ROLEID
+      } else {
+          config['iamRoleID'] = configLoader.AWS.USERSERVICES_ROLEID
+      }
     } else {
       error "Service Id is not available."
     }
@@ -89,6 +94,8 @@ node() {
   if (!config) {
     error "Failed to fetch service metadata from catalog"
   }
+
+  config['iamRoleARN'] = config['iamRoleID'].replaceAll("/", "\\\\/")
 
   dir(repo_name) {
     scmModule.setServiceConfig(config)
@@ -128,7 +135,8 @@ node() {
   def isEventSchdld = false
   def internalAccess = config['require_internal_access']
   domain = config['domain']
-  def roleARN = configLoader.AWS.ROLEID.replaceAll("/", "\\\\/")
+  def roleARN = config['iamRoleARN']
+  
   // @TODO: the below statement will be replaced with regular expression in very near future;
   def roleId = roleARN.substring(roleARN.indexOf("::") + 2, roleARN.lastIndexOf(":"))
 

--- a/builds/service-onboarding-build-pack/Jenkinsfile
+++ b/builds/service-onboarding-build-pack/Jenkinsfile
@@ -138,10 +138,16 @@ node  {
 			{
 				checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[credentialsId: repo_credential_id, url: scmModule.getTemplateUrl(service_template)]]])
 				def config = LoadConfiguration()
+				def roleARN
+			  if (service_config['domain'] && service_config['domain'] == "jazz") {
+			    roleARN = configLoader.AWS.PLATFORMSERVICES_ROLEID
+			  } else {
+			    roleARN = configLoader.AWS.USERSERVICES_ROLEID
+			  }
 				def serviceMetadataJson = [
 					"securityGroupIds": configLoader.AWS.SECURITY_GROUP_IDS,
 					"subnetIds": configLoader.AWS.SUBNET_IDS,
-					"iamRoleARN": configLoader.AWS.ROLEID
+					"iamRoleARN": roleARN
 				]
 				for (item in config) {
 					serviceMetadataJson[item.key] = item.value


### PR DESCRIPTION
### Requirements

Jazz needs a dedicated IAM role that has access to AWS services that Jazz components need (ex: SES, ES:POST etc.). 

### Description of the Change

Current IAM role that we create ($stackId_basic_execution) as part of stack creation is being used for user services as well as Jazz core services.

- Create $stackId_platform_services that has privileged permissions & remove permissions that $stackId_basic_execution might not need (SES:* for example).

- Assign this role to all Jazz core services so that all core services (functions) assume this role.

- Tag these two roles that we are creating (assuming terraform supports this, if not, we can skip this).

