### PR TITLE
Python3.X support on OSS 

### DIFF
--- a/builds/service-onboarding-build-pack/Jenkinsfile
+++ b/builds/service-onboarding-build-pack/Jenkinsfile
@@ -66,18 +66,15 @@ node  {
 
 		events.sendStartedEvent("VALIDATE_INPUT", 'input validation starts', context_map)
 		if (service_config['type'] == "api" || service_config['type'] == "lambda" || service_config['type'] == "function" || service_config['type'] == "website") {
-			if (service_config['runtime'] == "nodejs" || service_config['runtime'] == "python2.7" || service_config['runtime'] == "python3.6" || service_config['runtime'] == "java" ||  service_config['runtime'] == "n/a") {
+			if (service_config['runtime'] == "nodejs" || service_config['runtime'].startsWith("python") ||  service_config['runtime'] == "java" ||  service_config['runtime'] == "n/a") {
 
 				switch (service_config['type']) {
 					case "api":
 						if (service_config['runtime'] == "nodejs") {
 							service_template = "api-template-nodejs"
 						}
-						else if (service_config['runtime'] == "python2.7") {
-							service_template = 'api-template-python'
-						}
-						else if (service_config['runtime'] == "python3.6") {
-							service_template = 'api-template-python'
+						else if (service_config['runtime'].startsWith("python")){
+							service_template = 'api-template-python'	
 						}
 						else if (service_config['runtime'] == "java" ) {
 							service_template = 'api-template-java'
@@ -89,11 +86,8 @@ node  {
 						if (service_config['runtime'] == "nodejs") {
 							service_template = "lambda-template-nodejs"
 						}
-						else if (service_config['runtime'] == "python2.7" ) {
-							service_template = 'lambda-template-python'
-						}
-						else if (service_config['runtime'] == "python3.6") {
-							service_template = 'api-template-python'
+						else if (service_config['runtime'].startsWith("python")){
+							service_template = 'lambda-template-python'	
 						}
 						else if (service_config['runtime'] == "java" ) {
 							service_template = 'lambda-template-java'

--- a/core/jazz_create-serverless-service/swagger/swagger.json
+++ b/core/jazz_create-serverless-service/swagger/swagger.json
@@ -283,7 +283,8 @@
                     "enum": [
                         "nodejs",
                         "java",
-                        "python"
+                        "python2.7",
+                        "python3.6"
                     ]
                 },
                 "approvers": {

--- a/core/jazz_services/config/global-config.json
+++ b/core/jazz_services/config/global-config.json
@@ -109,7 +109,7 @@
         "active",
         "inactive"
     ],
-    "SERVICE_RUNTIMES": ["nodejs", "python", "java", "c#"],
+    "SERVICE_RUNTIMES": ["nodejs", "python2.7", "python3.6", "java", "c#"],
     "TYPE_FIELD_KEY": "type",
     "SERVICE_INTER_DEPENDENT_FIELDS_MAP": [
         {

--- a/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.html
+++ b/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.html
@@ -86,8 +86,14 @@
                         </section>
                         <section class="col-lg-3 col-md-3 pad-left0">
                             <div class="radio-container">
-                                <input type="radio" name="runtime" id="python" [value]="python" [checked]="runtime == 'python'" (change)="onSelectionChange('python')">
-                                <label for="python"><span class='outer'></span><span class="background"></span>Python (2.7)</label>
+                                <input type="radio" name="runtime" id="python2.7" [value]="python2.7" [checked]="runtime == 'python2.7'" (change)="onSelectionChange('python2.7')">
+                                <label for="python2.7"><span class='outer'></span><span class="background"></span>Python (2.7)</label>
+                            </div>
+                        </section>
+                        <section class="col-lg-3 col-md-3 pad-left0">
+                            <div class="radio-container">
+                                <input type="radio" name="runtime" id="python3.6" [value]="python3.6" [checked]="runtime == 'python3.6'" (change)="onSelectionChange('python3.6')">
+                                <label for="python3.6"><span class='outer'></span><span class="background"></span>Python (2.7)</label>
                             </div>
                         </section>
                         <section class="col-lg-3 col-md-3 pad-left0">

--- a/templates/api-template-python/deployment-env.yml
+++ b/templates/api-template-python/deployment-env.yml
@@ -1,3 +1,2 @@
-providerRuntime : python2.7
 providerMemorySize : 256
 providerTimeout : 160

--- a/templates/lambda-template-python/deployment-env.yml
+++ b/templates/lambda-template-python/deployment-env.yml
@@ -1,3 +1,2 @@
-providerRuntime : python2.7
 providerMemorySize : 256
 providerTimeout : 160


### PR DESCRIPTION
### Requirements

Python3.X support on OSS.
Follow up PR for https://github.com/tmobile/jazz/pull/661

### Description of the Change

- Removed providerRuntime from both api/lambda Templates
- Used startsWith function for checking python runtime.
- Added python3.6 runtime radio button on Jazz UI
-  Updated global-config with python2.7/3.6 instead of python
- Updated swagger file fro jazz_create Serverless service

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
