### PR TITLE
Use dedicated IAM role for platform services

### DIFF
--- a/builds/delete-serverless-service-build-pack/Jenkinsfile
+++ b/builds/delete-serverless-service-build-pack/Jenkinsfile
@@ -455,7 +455,7 @@ def updateSwaggerConfig() {
 
 			def region = "${configLoader.AWS.REGION}"
       
-			def roleARN = service_config['iamRoleARN'].replaceAll("/", "\\\\/")
+			def roleARN = configLoader.AWS.PLATFORMSERVICES_ROLEID.replaceAll("/", "\\\\/")
 
 			// TODO: the below couple of statements will be replaced with regular expression in very near future;
 			def roleId = roleARN.substring(roleARN.indexOf("::") + 2, roleARN.lastIndexOf(":"))

--- a/builds/jazz-build-module/service-configuration-data-loader.groovy
+++ b/builds/jazz-build-module/service-configuration-data-loader.groovy
@@ -44,7 +44,6 @@ def loadServiceConfigurationData() {
         if (fileExists('swagger/swagger.json')) {
             //Swagger SEDs
             echo "Updating the Swagger SEDs"
-            sh "sed -i -- 's|{conf-role}|${role_arn}|g' ./swagger/swagger.json"
             sh "sed -i -- 's/{conf-region}/${region}/g' ./swagger/swagger.json"
             sh "sed -i -- 's/{conf-accId}/${role_id}/g' ./swagger/swagger.json"
         }

--- a/builds/jenkins-build-pack-api/Jenkinsfile
+++ b/builds/jenkins-build-pack-api/Jenkinsfile
@@ -736,7 +736,7 @@ def createSubscriptionFilters(stackName, region, roleId) {
 	} catch (Exception ex) { }// ignore error if not created yet
 
 	try {
-		sh "aws logs put-subscription-filter --output json --log-group-name \"${lambda}\" --filter-name \"${lambda}\" --filter-pattern \"\" --destination-arn \"${logStreamer}\" --region ${region} --role-arn \"arn:aws:iam::${roleId}:role/${configLoader.INSTANCE_PREFIX}_platform_services\""
+		sh "aws logs put-subscription-filter --output json --log-group-name \"${lambda}\" --filter-name \"${lambda}\" --filter-pattern \"\" --destination-arn \"${logStreamer}\" --region ${region} --role-arn ${configLoader.AWS.PLATFORMSERVICES_ROLEID}"
 	} catch (Exception ex) {
 		echo "error occured: " + ex.getMessage()
 	}

--- a/builds/jenkins-build-pack-api/Jenkinsfile
+++ b/builds/jenkins-build-pack-api/Jenkinsfile
@@ -525,7 +525,7 @@ def generateSwaggerEnv(env, deploymentNode, apiHostName, config) {
 	// TODO: the below couple of statements will be replaced with regular expression in very near future;
 	def roleId = config['iamRoleARN'].substring(config['iamRoleARN'].indexOf("::") + 2, config['iamRoleARN'].lastIndexOf(":"))
 
-	sh "sed -i -- 's|{conf-role}|${config['iamRoleARN']}|g' ./swagger/swagger.json"
+	sh "sed -i -- 's|{conf-role}|${configLoader.AWS.PLATFORMSERVICES_ROLEID}|g' ./swagger/swagger.json"
 	sh "sed -i -- 's/{conf-region}/${configLoader.AWS.REGION}/g' ./swagger/swagger.json"
 	sh "sed -i -- 's/{conf-accId}/${roleId}/g' ./swagger/swagger.json"
 }
@@ -736,7 +736,7 @@ def createSubscriptionFilters(stackName, region, roleId) {
 	} catch (Exception ex) { }// ignore error if not created yet
 
 	try {
-		sh "aws logs put-subscription-filter --output json --log-group-name \"${lambda}\" --filter-name \"${lambda}\" --filter-pattern \"\" --destination-arn \"${logStreamer}\" --region ${region} --role-arn \"arn:aws:iam::${roleId}:role/${configLoader.INSTANCE_PREFIX}_basic_execution\""
+		sh "aws logs put-subscription-filter --output json --log-group-name \"${lambda}\" --filter-name \"${lambda}\" --filter-pattern \"\" --destination-arn \"${logStreamer}\" --region ${region} --role-arn \"arn:aws:iam::${roleId}:role/${configLoader.INSTANCE_PREFIX}_platform_services\""
 	} catch (Exception ex) {
 		echo "error occured: " + ex.getMessage()
 	}

--- a/builds/jenkins-build-pack-lambda/Jenkinsfile
+++ b/builds/jenkins-build-pack-lambda/Jenkinsfile
@@ -728,7 +728,7 @@ def createSubscriptionFilters(stackName, region, roleId) {
     }
   } catch (Exception ex) { } // ignore error if not created yet
   try {
-    sh "aws logs put-subscription-filter --output json --log-group-name \"${lambda}\" --filter-name \"${lambda}\" --filter-pattern \"\" --destination-arn \"${logStreamer}\" --region ${region} --role-arn \"arn:aws:iam::${roleId}:role/${configLoader.INSTANCE_PREFIX}_basic_execution\""
+    sh "aws logs put-subscription-filter --output json --log-group-name \"${lambda}\" --filter-name \"${lambda}\" --filter-pattern \"\" --destination-arn \"${logStreamer}\" --region ${region} --role-arn \"arn:aws:iam::${roleId}:role/${configLoader.INSTANCE_PREFIX}_platform_services\""
   } catch (Exception ex) {
     echo "error occured: " + ex.getMessage()
   }

--- a/builds/jenkins-build-pack-lambda/Jenkinsfile
+++ b/builds/jenkins-build-pack-lambda/Jenkinsfile
@@ -728,7 +728,7 @@ def createSubscriptionFilters(stackName, region, roleId) {
     }
   } catch (Exception ex) { } // ignore error if not created yet
   try {
-    sh "aws logs put-subscription-filter --output json --log-group-name \"${lambda}\" --filter-name \"${lambda}\" --filter-pattern \"\" --destination-arn \"${logStreamer}\" --region ${region} --role-arn \"arn:aws:iam::${roleId}:role/${configLoader.INSTANCE_PREFIX}_platform_services\""
+    sh "aws logs put-subscription-filter --output json --log-group-name \"${lambda}\" --filter-name \"${lambda}\" --filter-pattern \"\" --destination-arn \"${logStreamer}\" --region ${region} --role-arn ${configLoader.AWS.PLATFORMSERVICES_ROLEID}"
   } catch (Exception ex) {
     echo "error occured: " + ex.getMessage()
   }


### PR DESCRIPTION
### Requirements

Replace the iam user role with platform role for create the subscription filters and loggroup, swagger files, Generate the swagger files etc

### Description of the Change

As part of IAM role split, replace the iam user role with platform role for create the subscription filters and loggroup, swagger files, Generate the swagger files etc

### Benefits

Basic lambda execution role with less policies

### Possible Drawbacks

NA

### Applicable Issues

NA
