### PR TITLE
Bug fix for jazz_cognito-admin-authorizer

### DIFF
--- a/core/jazz_cognito-admin-authorizer/index.js
+++ b/core/jazz_cognito-admin-authorizer/index.js
@@ -218,7 +218,7 @@ module.exports.handler = (event, context, cb) => {
    * @class AuthPolicy
    * @constructor
    */
-  var AuthPolicy = (principal, awsAccountId, apiOptions) => {
+  function AuthPolicy(principal, awsAccountId, apiOptions) {
     /**
      * The AWS account id the policy will be generated for. This is used to create
      * the method ARNs.
@@ -312,7 +312,7 @@ module.exports.handler = (event, context, cb) => {
      * @param {Object} The conditions object in the format specified by the AWS docs.
      * @return {void}
      */
-    var addMethod = (effect, verb, resource, conditions) => {
+    function addMethod(effect, verb, resource, conditions) {
       if (verb !== "*" && !AuthPolicy.HttpVerb.hasOwnProperty(verb)) {
         throw new Error(`Invalid HTTP verb ${verb}. Allowed verbs in AuthPolicy.HttpVerb`);
       }
@@ -402,7 +402,7 @@ module.exports.handler = (event, context, cb) => {
        *
        * @method allowAllMethods
        */
-      allowAllMethods: () => {
+      allowAllMethods: function () {
         addMethod.call(this, "allow", "*", "*", null);
       },
 
@@ -411,7 +411,7 @@ module.exports.handler = (event, context, cb) => {
        *
        * @method denyAllMethods
        */
-      denyAllMethods: () => {
+      denyAllMethods: function () {
         addMethod.call(this, "deny", "*", "*", null);
       },
 
@@ -425,7 +425,7 @@ module.exports.handler = (event, context, cb) => {
        * @param {string} The resource path. For example "/pets"
        * @return {void}
        */
-      allowMethod: (verb, resource) => {
+      allowMethod: function(verb, resource) {
         addMethod.call(this, "allow", verb, resource, null);
       },
 
@@ -439,7 +439,7 @@ module.exports.handler = (event, context, cb) => {
        * @param {string} The resource path. For example "/pets"
        * @return {void}
        */
-      denyMethod: (verb, resource) => {
+      denyMethod: function(verb, resource) {
         addMethod.call(this, "deny", verb, resource, null);
       },
 
@@ -455,7 +455,7 @@ module.exports.handler = (event, context, cb) => {
        * @param {Object} The conditions object in the format specified by the AWS docs
        * @return {void}
        */
-      allowMethodWithConditions: (verb, resource, conditions) => {
+      allowMethodWithConditions: function(verb, resource, conditions) {
         addMethod.call(this, "allow", verb, resource, conditions);
       },
 
@@ -471,7 +471,7 @@ module.exports.handler = (event, context, cb) => {
        * @param {Object} The conditions object in the format specified by the AWS docs
        * @return {void}
        */
-      denyMethodWithConditions: (verb, resource, conditions) => {
+      denyMethodWithConditions: function(verb, resource, conditions) {
         addMethod.call(this, "deny", verb, resource, conditions);
       },
 
@@ -484,7 +484,7 @@ module.exports.handler = (event, context, cb) => {
        * @method build
        * @return {Object} The policy object that can be serialized to JSON.
        */
-      build: () => {
+      build: function() {
         if ((!this.allowMethods || this.allowMethods.length === 0) &&
           (!this.denyMethods || this.denyMethods.length === 0)) {
           throw new Error("No statements defined for the policy");

--- a/core/jazz_cognito-admin-authorizer/index.js
+++ b/core/jazz_cognito-admin-authorizer/index.js
@@ -80,7 +80,7 @@ module.exports.handler = (event, context, cb) => {
     ValidateToken(pems, event, context, config, cb);
   }
 
-  var ValidateToken = (pems, event, context, config, cb) => {
+  function ValidateToken(pems, event, context, config, cb) {
     logger.info("Inside ValidateToken");
     let token = event.authorizationToken;
     //Fail if the token is not jwt

--- a/core/jazz_create-serverless-service/index.js
+++ b/core/jazz_create-serverless-service/index.js
@@ -73,7 +73,7 @@ var handler = (event, context, cb) => {
         getToken(config)
             .then((authToken) => getServiceData(service_creation_data, authToken, config))
             .then((inputs) => createService(inputs))
-            .then(() => updateAclPolicy(serviceId, authToken, user_id, "admin", "manage", config))
+            .then((authToken) => updateAclPolicy(serviceId, authToken, user_id, "admin", "manage", config))
             .then(() => startServiceOnboarding(service_creation_data, config, serviceId))
             .then((result) => {
                 cb(null, responseObj(result, service_creation_data));

--- a/core/jazz_create-serverless-service/index.js
+++ b/core/jazz_create-serverless-service/index.js
@@ -76,7 +76,7 @@ var handler = (event, context, cb) => {
             .then((authToken) => updateAclPolicy(serviceId, authToken, user_id, "admin", "manage", config))
             .then(() => startServiceOnboarding(service_creation_data, config, serviceId))
             .then((result) => {
-                cb(null, responseObj(result, service_creation_data));
+                return cb(null, responseObj(result, service_creation_data));
             })
             .catch(function (err) {
                 logger.error('Error while creating service : ' + JSON.stringify(err));
@@ -390,7 +390,7 @@ var updateAclPolicy = (serviceId, authToken, user_id, permission, category, conf
                     resolve("success");
                 } else {
                     logger.error(`Error while updating policies using ACL: ${JSON.stringify(response)}`);
-                    reject(`Error while updating policies using ACL.`);
+                    reject({result: "internalError", message: `Error while updating policies using ACL.`});
                 }
             }
         });


### PR DESCRIPTION
### Requirements

* Bug fix for jazz_cognito-admin-authorizer and jazz_create-serverless-service services.

### Description of the Change

* jazz_cognito-admin-authorizer: fixed constructor error that as arrow functions don't have this, they cannot be used as constructor.
* jazz_create-serverless-service: Passing authToken param to updateAclPolicy() and fix for error handling.

### Benefits

* jazz_cognito-admin-authorizer successfully validates the for admin authorization.
* jazz_create-serverless-service successfully send request to ACL service to update the policies for user created service.

### Possible Drawbacks

NA

### Applicable Issues

NA