### PR TITLE
Advanced column-wise filter

### DIFF
--- a/core/jazz_services/components/crud/getList.js
+++ b/core/jazz_services/components/crud/getList.js
@@ -76,7 +76,7 @@ module.exports = (query, getAllRecords, onComplete) => {
                     };
                 });
             } else if (query[key]) {
-                filter = filter + key_name + " = :" + key_name + insertAnd;
+                filter = filter + `contains(${key_name}, :${key_name})` + insertAnd;
                 attributeValues[(":" + key_name)] = {
                     'S': query[key]
                 };


### PR DESCRIPTION
 Advanced column-wise filtering for both "Name" & "Namespace" like global search.
### Description of the Change
Previously filter for both columns are based on the exact match of search pattern. Now returns the list with column value contains the search pattern.   

![untitled1](https://user-images.githubusercontent.com/33832466/50680192-cdde1580-102c-11e9-9e3d-3ff06bf06fa7.jpg)

![untitled2](https://user-images.githubusercontent.com/33832466/50680202-d6cee700-102c-11e9-861a-0d4366bdf419.jpg)

### Benefits

![untitled3](https://user-images.githubusercontent.com/33832466/50679871-47750400-102b-11e9-8051-cbd3256793b1.jpg)


### Possible Drawbacks

NA

### Applicable Issues

NA
