### PR TITLE
fix  disable delete button for  core jazz services

### DIFF
--- a/core/jazz_ui/src/app/pages/service-detail/service-detail.component.ts
+++ b/core/jazz_ui/src/app/pages/service-detail/service-detail.component.ts
@@ -168,11 +168,9 @@ export class ServiceDetailComponent implements OnInit {
           'link': ''
         }]
       this.isLoadingService = false;
-      if (service.status == 'deletion_completed' || service.status == 'deletion_started' || service.status == 'creation_started' || service.status == 'creation_failed')
+      if (service.status == 'deletion_completed' || service.status == 'deletion_started' || service.status == 'creation_started' || service.status == 'creation_failed' || (!service.repository && service.domain == 'jazz'))
         this.canDelete = false;
-      
-      if (!service.repository && service.domain == 'jazz')
-        this.canDelete = false;
+
     } else {
       this.isLoadingService = false;
       let errorMessage = this.toastmessage.successMessage(service, "serviceDetail");

--- a/core/jazz_ui/src/app/pages/service-detail/service-detail.component.ts
+++ b/core/jazz_ui/src/app/pages/service-detail/service-detail.component.ts
@@ -170,6 +170,9 @@ export class ServiceDetailComponent implements OnInit {
       this.isLoadingService = false;
       if (service.status == 'deletion_completed' || service.status == 'deletion_started' || service.status == 'creation_started' || service.status == 'creation_failed')
         this.canDelete = false;
+      
+      if (!service.repository && service.domain == 'jazz')
+        this.canDelete = false;
     } else {
       this.isLoadingService = false;
       let errorMessage = this.toastmessage.successMessage(service, "serviceDetail");
@@ -235,7 +238,9 @@ export class ServiceDetailComponent implements OnInit {
   };
 
   env(event) {
-    if ((event != 'creation failed') && (event != 'creation started') && (event != 'deletion started') && (event != 'deletion completed')) {
+    if (!this.service.repository && this.service.domain == 'jazz') {
+      this.canDelete = false;
+    } else if ((event != 'creation failed') && (event != 'creation started') && (event != 'deletion started') && (event != 'deletion completed')) {
       this.canDelete = true;
     } else {
       this.canDelete = false;


### PR DESCRIPTION
### Requirements

Disable delete button for  core jazz services

From services list 
click on logs(any core jazz services)
user can able to click on **DELETE SERVICE**


### Description of the Change

Added condition to check if the **domain** is **jazz** and **repository** details is **null**

### Benefits

Previously
User can able to click delete for core services 
![core-service-delete](https://user-images.githubusercontent.com/45478471/51606232-5e768a00-1f37-11e9-94ac-ae8b2e0d6d3c.png)

Currently
Delete service  button will be in disable state for core services
### Possible Drawbacks
NA

### Applicable Issues
NA
