### PR TITLE
add azure function test for test_lambda

### DIFF
--- a/core/jazz_test-lambda/components/utils.js
+++ b/core/jazz_test-lambda/components/utils.js
@@ -34,6 +34,16 @@ var validateARN = (arn) => {
   }
 
 };
+
+var validateEndpoint = (arn) => {
+  if (arn && arn.startsWith("http")) {
+    return true;
+  } else {
+    return validateARN(arn);
+  }
+
+};
+
 var execStatus = () => {
   return {
     "success": "Success",
@@ -45,5 +55,6 @@ var execStatus = () => {
 
 module.exports = {
   validateARN,
+  validateEndpoint,
   execStatus
 };

--- a/core/jazz_test-lambda/package.json
+++ b/core/jazz_test-lambda/package.json
@@ -18,6 +18,7 @@
     "aws-sdk-mock": "^1.7.0",
     "aws-lambda-mock-context": "^3.1.1",
     "istanbul": "^0.4.5",
-    "sinon": "^5.0.7"
+    "sinon": "^5.0.7",
+    "nock": "^9.0.2"
   }
 }

--- a/core/jazz_test-lambda/test/test.js
+++ b/core/jazz_test-lambda/test/test.js
@@ -99,6 +99,18 @@ describe('handler', () => {
     });
   })
 
+  it("should NOT call invokeLambda for http endpoint", (done) => {
+    event.body.functionARN = "https://";
+    var tempobj = {};
+    var invokeLambdaStub = sinon.stub(index, 'invokeLambda').resolves(tempobj);
+    index.handler(event, context, (error, records) => {
+      sinon.assert.notCalled(invokeLambdaStub);
+      invokeLambdaStub.restore();
+      done();
+    });
+  })
+
+
   it("should return execStatus success if lambda execution is succesfull", (done) => {
     var tempobj = {
       "StatusCode": 200,

--- a/core/jazz_test-lambda/test/testHttp.js
+++ b/core/jazz_test-lambda/test/testHttp.js
@@ -1,0 +1,60 @@
+
+const expect = require('chai').expect;
+const index = require('../index');
+const nock = require('nock');
+const endpointHost = "https://localhost/admin/functions";
+const endpointPath = "/myfunction?code=xyz";
+
+let event;
+
+describe('handler', () => {
+
+    function stub(statusCode) {
+        nock(endpointHost)
+            .post(endpointPath)
+            .reply(statusCode, "{}");
+
+    }
+    describe('invoke http', () => {
+        beforeEach(() => {
+
+            event = {
+                "method": "POST",
+                "stage": "test",
+                "query": {
+                    "service_name": "jazz-service",
+                    "username": "xyz",
+                    "last_evaluated_key": undefined
+                },
+                "body": {
+                    "functionARN": endpointHost + endpointPath,
+                    "inputJSON": {
+                        "name": "applesdadasdasd777"
+                    }
+                }
+            };
+
+        });
+
+        it('endpoint OK', (done) => {
+            stub(202);
+            index.handler(event, context, (error, records) => {
+                expect(records.data.execStatus).to.eq("Success");
+                expect(records.data.payload.StatusCode).to.eq(200);
+                expect(records.input.functionARN).to.eq(endpointHost + endpointPath);
+                done();
+            });
+        });
+
+        it('endpoint error response', (done) => {
+            stub(500);
+            index.handler(event, context, (error, records) => {
+                expect(records.data.execStatus).to.eq("FunctionInvocationError");
+                expect(records.data.payload.StatusCode).to.eq(500);
+                expect(records.input.functionARN).to.eq(endpointHost + endpointPath);
+                done();
+            });
+        });
+    });
+
+})


### PR DESCRIPTION
### Requirements

* Currently AWS lambda is tested via lambda invoke which does not work for azure function
* Added a new way to test lambda API to test azure function via http invoke

### Description of the Change

Added a http call to very azure function

### Benefits

Support azure function testing from Jazz UI

### Possible Drawbacks

None, I added a separate flow for aws lambda vs azure function.  The existing lambda invoke stays the same.

### Applicable Issues

<!-- Enter any applicable Issues here -->
