### PR TITLE
:bud: Fixing environment logical id issue

### DIFF
--- a/builds/jenkins-build-pack-website/Jenkinsfile
+++ b/builds/jenkins-build-pack-website/Jenkinsfile
@@ -76,20 +76,21 @@ node()  {
 
 	environmentDeploymentMetadata.initialize(service_config, configLoader, scmModule, branch, env.BUILD_URL, env.BUILD_ID, g_base_url + "/jazz/environments", auth_token)
 
-	def environment_logical_id = environmentDeploymentMetadata.getEnvironmentLogicalId();
+	def environment_logical_id
 	if (params.scm_branch == 'master') {
-		environment = 'prod'
+		environment_logical_id = 'prod'
 		current_environment = 'PROD'
 		s3Bucket = configLoader.JAZZ.S3.WEBSITE_PROD_BUCKET;
 	} else {
-		if (environment_logical_id) {
-			environment = environment_logical_id
-		} else {
+    environment_logical_id = environmentDeploymentMetadata.getEnvironmentLogicalId();
+		if (!environment_logical_id) {
 			error "The environment has not been created yet and its missing the logical Id"
 		}
 		current_environment = "DEV"
 		s3Bucket = configLoader.JAZZ.S3.WEBSITE_DEV_BUCKET;
 	}
+
+  environment = environment_logical_id
 
 	if (!events) { error "Can't load events module"	} //Fail here
 	events.initialize(configLoader, service_config, "SERVICE_DEPLOYMENT", branch, environment, g_base_url + "/jazz/events")


### PR DESCRIPTION
### Requirements

Bug fix for taking the environment logical id value

### Description of the Change

Since we have both stg and prod environments for master branch, environment logical id chosen is wrong for prod environment (in website build workflow) .

### Benefits

User will be able to see the deployment/environment related details corresponding to each environment.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
