### PR TITLE
Ensure that aws profiles are getting cleared/deleted after each build completion

### DIFF
--- a/builds/delete-serverless-service-build-pack/Jenkinsfile
+++ b/builds/delete-serverless-service-build-pack/Jenkinsfile
@@ -849,7 +849,9 @@ def cleanupS3BucketPolicy(stage, assetInfo) {
 def resetCredentials(credsId) {
 	echo "resetting AWS credentials"
   def credPath = System.getenv().HOME + "/.aws/credentials"
-	sh "sed -i '/${credsId}/,+2d' ${credPath}"
+  def confPath = System.getenv().HOME + "/.aws/config"
+  sh "sed -i '/${credsId}/,+2d' ${credPath}"
+  sh "sed -i '/${credsId}/,+1d' ${confPath}"
 }
 @NonCPS
 def updateBucketPolicy(policy_json, bucketName){

--- a/builds/delete-serverless-service-build-pack/Jenkinsfile
+++ b/builds/delete-serverless-service-build-pack/Jenkinsfile
@@ -848,8 +848,6 @@ def cleanupS3BucketPolicy(stage, assetInfo) {
  */
 def resetCredentials(credsId) {
 	echo "resetting AWS credentials"
-	sh "aws configure set profile.${credsId}.aws_access_key_id XXXXXXXXXXXXXXXXXXXXXXXXXX"
-	sh "aws configure set profile.${credsId}.aws_secret_access_key XXXXXXXXXXXXXXXXXXXXXX"
   def credPath = System.getenv().HOME + "/.aws/credentials"
 	sh "sed -i '/${credsId}/,+2d' ${credPath}"
 }

--- a/builds/delete-serverless-service-build-pack/Jenkinsfile
+++ b/builds/delete-serverless-service-build-pack/Jenkinsfile
@@ -850,6 +850,8 @@ def resetCredentials(credsId) {
 	echo "resetting AWS credentials"
 	sh "aws configure set profile.${credsId}.aws_access_key_id XXXXXXXXXXXXXXXXXXXXXXXXXX"
 	sh "aws configure set profile.${credsId}.aws_secret_access_key XXXXXXXXXXXXXXXXXXXXXX"
+  def credPath = System.getenv().HOME + "/.aws/credentials"
+	sh "sed -i '/${credsId}/,+2d' ${credPath}"
 }
 @NonCPS
 def updateBucketPolicy(policy_json, bucketName){

--- a/builds/jenkins-build-pack-api/Jenkinsfile
+++ b/builds/jenkins-build-pack-api/Jenkinsfile
@@ -579,7 +579,9 @@ def setLambdaExecutionRole(role) {
 def resetCredentials(credsId) {
 	echo "resetting AWS credentials"
 	def credPath = System.getenv().HOME + "/.aws/credentials"
-	sh "sed -i '/${credsId}/,+2d' ${credPath}"
+  def confPath = System.getenv().HOME + "/.aws/config"
+  sh "sed -i '/${credsId}/,+2d' ${credPath}"
+  sh "sed -i '/${credsId}/,+1d' ${confPath}"
 }
 
 /**

--- a/builds/jenkins-build-pack-api/Jenkinsfile
+++ b/builds/jenkins-build-pack-api/Jenkinsfile
@@ -580,6 +580,8 @@ def resetCredentials(credsId) {
 	echo "resetting AWS credentials"
 	sh "aws configure set profile.${credsId}.aws_access_key_id XXXXXXXXXXXXXXXXXXXXXXXXXX"
 	sh "aws configure set profile.${credsId}.aws_secret_access_key XXXXXXXXXXXXXXXXXXXXXX"
+	def credPath = System.getenv().HOME + "/.aws/credentials"
+	sh "sed -i '/${credsId}/,+2d' ${credPath}"
 }
 
 /**

--- a/builds/jenkins-build-pack-api/Jenkinsfile
+++ b/builds/jenkins-build-pack-api/Jenkinsfile
@@ -578,8 +578,6 @@ def setLambdaExecutionRole(role) {
  */
 def resetCredentials(credsId) {
 	echo "resetting AWS credentials"
-	sh "aws configure set profile.${credsId}.aws_access_key_id XXXXXXXXXXXXXXXXXXXXXXXXXX"
-	sh "aws configure set profile.${credsId}.aws_secret_access_key XXXXXXXXXXXXXXXXXXXXXX"
 	def credPath = System.getenv().HOME + "/.aws/credentials"
 	sh "sed -i '/${credsId}/,+2d' ${credPath}"
 }

--- a/builds/jenkins-build-pack-lambda/Jenkinsfile
+++ b/builds/jenkins-build-pack-lambda/Jenkinsfile
@@ -576,8 +576,6 @@ def buildLambda(String runtime, String repo_name) {
  */
 def resetCredentials(credsId) {
   echo "resetting AWS credentials"
-  sh "aws configure set profile.${credsId}.aws_access_key_id XXXXXXXXXXXXXXXXXXXXXXXXXX"
-  sh "aws configure set profile.${credsId}.aws_secret_access_key XXXXXXXXXXXXXXXXXXXXXX"
   def credPath = System.getenv().HOME + "/.aws/credentials"
 	sh "sed -i '/${credsId}/,+2d' ${credPath}"
 }

--- a/builds/jenkins-build-pack-lambda/Jenkinsfile
+++ b/builds/jenkins-build-pack-lambda/Jenkinsfile
@@ -578,6 +578,8 @@ def resetCredentials(credsId) {
   echo "resetting AWS credentials"
   sh "aws configure set profile.${credsId}.aws_access_key_id XXXXXXXXXXXXXXXXXXXXXXXXXX"
   sh "aws configure set profile.${credsId}.aws_secret_access_key XXXXXXXXXXXXXXXXXXXXXX"
+  def credPath = System.getenv().HOME + "/.aws/credentials"
+	sh "sed -i '/${credsId}/,+2d' ${credPath}"
 }
 
 /** Validate basic configurations in the deployment yaml file and error if any keys are

--- a/builds/jenkins-build-pack-lambda/Jenkinsfile
+++ b/builds/jenkins-build-pack-lambda/Jenkinsfile
@@ -577,7 +577,9 @@ def buildLambda(String runtime, String repo_name) {
 def resetCredentials(credsId) {
   echo "resetting AWS credentials"
   def credPath = System.getenv().HOME + "/.aws/credentials"
-	sh "sed -i '/${credsId}/,+2d' ${credPath}"
+  def confPath = System.getenv().HOME + "/.aws/config"
+  sh "sed -i '/${credsId}/,+2d' ${credPath}"
+  sh "sed -i '/${credsId}/,+1d' ${confPath}"
 }
 
 /** Validate basic configurations in the deployment yaml file and error if any keys are

--- a/builds/jenkins-build-pack-website/Jenkinsfile
+++ b/builds/jenkins-build-pack-website/Jenkinsfile
@@ -631,6 +631,8 @@ def resetCredentials(credsId) {
   echo "resetting AWS credentials"
 	sh "aws configure set profile.${credsId}.aws_access_key_id XXXXXXXXXXXXXXXXXXXXXXXXXX"
   sh "aws configure set profile.${credsId}.aws_secret_access_key XXXXXXXXXXXXXXXXXXXXXX"
+	def credPath = System.getenv().HOME + "/.aws/credentials"
+	sh "sed -i '/${credsId}/,+2d' ${credPath}"
 }
 
 /**

--- a/builds/jenkins-build-pack-website/Jenkinsfile
+++ b/builds/jenkins-build-pack-website/Jenkinsfile
@@ -629,8 +629,6 @@ def LoadConfiguration() {
 */
 def resetCredentials(credsId) {
   echo "resetting AWS credentials"
-	sh "aws configure set profile.${credsId}.aws_access_key_id XXXXXXXXXXXXXXXXXXXXXXXXXX"
-  sh "aws configure set profile.${credsId}.aws_secret_access_key XXXXXXXXXXXXXXXXXXXXXX"
 	def credPath = System.getenv().HOME + "/.aws/credentials"
 	sh "sed -i '/${credsId}/,+2d' ${credPath}"
 }

--- a/builds/jenkins-build-pack-website/Jenkinsfile
+++ b/builds/jenkins-build-pack-website/Jenkinsfile
@@ -630,7 +630,9 @@ def LoadConfiguration() {
 def resetCredentials(credsId) {
   echo "resetting AWS credentials"
 	def credPath = System.getenv().HOME + "/.aws/credentials"
-	sh "sed -i '/${credsId}/,+2d' ${credPath}"
+  def confPath = System.getenv().HOME + "/.aws/config"
+  sh "sed -i '/${credsId}/,+2d' ${credPath}"
+  sh "sed -i '/${credsId}/,+1d' ${confPath}"
 }
 
 /**


### PR DESCRIPTION
### Requirements

Ensure aws profiles are getting cleared/deleted after each build completion

### Description of the change

Currently we have issues with builds as the aws profiles are not cleared after build completion.

Possible reasons for the build issues:
1. We’ll need to clear the profile (reset keys) after every build.  It might mean that the change to use a new random profile name with every build had a bug (not clearing our profiles/keys).
2.  Clearing just the keys would still leave the profile (with dummy keys) in the creds file. This will make the file larger & larger. We’ll need to find a way to remove the profile  after the build instead of just clearing out the keys.

This change deletes the aws profile (references) after the builds gets completed (success/fail).

### Possible Drawbacks

NA

### Applicable Issues

NA
