### PR TITLE
Fix Python3.6 Templates : Attribute issue while raising Exception

### DIFF
--- a/templates/api-template-python/index.py
+++ b/templates/api-template-python/index.py
@@ -48,11 +48,10 @@ def handler(event, context):
     except Exception as e:
         # Exception Handling
         exception_type = e.__class__.__name__
-        exception_message = e.message
 
         # Create a JSON string here
         api_exception_json = CustomErrors.throwInternalServerError(
-            exception_message)
+            str(e))
         raise LambdaException(api_exception_json)
 
 


### PR DESCRIPTION
### Requirements

Fixing Attribute error, while raising an exception in try block.

### Description of the Change

This occurs due to removal of **Exception.message** in Python3 versions. Fixed it by passing the  instance of exception **e** to get the custom message.
### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
