### PR TITLE
Remove primary account role-policy

### DIFF
--- a/builds/jenkins-delete-resources/Jenkinsfile
+++ b/builds/jenkins-delete-resources/Jenkinsfile
@@ -10,6 +10,7 @@ import groovy.json.JsonOutput
 @Field def isPrimary = false
 
 
+
 // To be replaced as @Field def repo_credential_id = "value" for repo_credential_id, repo_base and repo_core
 @Field def repo_credential_id 
 @Field def aws_credential_id 
@@ -101,7 +102,8 @@ node {
       }
     }
    } else {
-    echo "Primary account can not be deleted this way, skipping...."
+    // Delete the Role Policy update for Accessing cross Account Metrics
+    deletePrimaryAccountPolicy(credentialId)
    }
   }
  } else {
@@ -341,6 +343,36 @@ def deletes3Bucket(bucketName) {
  } catch (ex) {
   echo "${ex.getMessage()}"
  }
+}
+
+/**
+  Function for Deleting Primary Account Role Policy
+  Accepts credentialId 
+  Check if policy exists and delete it
+**/
+def deletePrimaryAccountPolicy(credentialId){
+  try {
+    def status = true;
+    withCredentials([
+      [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "${credentialId}"]
+      ]) {
+        try {
+          sh "aws iam get-role-policy --role-name ${instance_prefix}_platform_services --policy-name ${instance_prefix}_NonPrimaryAssumePolicy"
+          } catch (ex) {
+            echo "${instance_prefix}_NonPrimaryAssumePolicy not exists"
+            status = false
+          }
+          
+          if (status) {
+            sh "aws iam delete-role-policy --role-name ${instance_prefix}_platform_services --policy-name ${instance_prefix}_NonPrimaryAssumePolicy"
+            sleep(time: 30, unit: "SECONDS")
+          } else {
+            echo "${instance_prefix}_NonPrimaryAssumePolicy not exists"
+          }
+      }
+    } catch (ex) {
+      echo "${ex.getMessage()}"
+    }
 }
 
 def getBuildModuleUrl() {


### PR DESCRIPTION
### Requirements

While enabling multi-account feature we are creating couples of roles in non-primary account also we are updating the platform_services role of primary account to talk with cross-accounts. We are in need to drop the roles created by multi-account feature before stack destroy.

### Description of the Change

- updated with the deletion of platform_services  role on primary Account



### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
