### PR TITLE
Fix for multi account stack changes (for core service deployment)

### DIFF
--- a/builds/jazz-build-module/service-metadata-loader.groovy
+++ b/builds/jazz-build-module/service-metadata-loader.groovy
@@ -49,8 +49,13 @@ def loadServiceMetadata(service_id){
 			metadata['created_by'] = service_data.Item.SERVICE_CREATED_BY.S
 			metadata['type'] = service_data.Item.SERVICE_TYPE.S
 			metadata['runtime'] = service_data.Item.SERVICE_RUNTIME.S
-			metadata['accountId'] = service_data.Item.SERVICE_DEPLOYMENT_ACCOUNTS.L[0].M.accountId.S
-      metadata['region'] = service_data.Item.SERVICE_DEPLOYMENT_ACCOUNTS.L[0].M.region.S
+			if(service_data.Item.SERVICE_DEPLOYMENT_ACCOUNTS){
+			    metadata['accountId'] = service_data.Item.SERVICE_DEPLOYMENT_ACCOUNTS.L[0].M.accountId.S
+                metadata['region'] = service_data.Item.SERVICE_DEPLOYMENT_ACCOUNTS.L[0].M.region.S
+			} else {
+			    metadata['accountId'] = configLoader.AWS.DEFAULTS.ACCOUNTID
+                metadata['region'] = configLoader.AWS.DEFAULTS.REGION
+			}
 			metadata['catalog_metadata'] = catalog_metadata
 			if(service_data.Item.SERVICE_SLACK_CHANNEL)
 				metadata['slack_channel'] = service_data.Item.SERVICE_SLACK_CHANNEL.S

--- a/core/jazz_ui/package.json
+++ b/core/jazz_ui/package.json
@@ -27,7 +27,7 @@
     "@ng-bootstrap/ng-bootstrap": "^1.0.0-alpha.26",
     "@ng-idle/core": "2.0.0-beta.12",
     "@ng-idle/keepalive": "2.0.0-beta.12",
-    "@types/lodash": "^4.14.111",
+    "@types/lodash": "4.14.111",
     "angular2-moment": "^1.6.0",
     "angular2-number-picker": "^0.8.8",
     "angular2-toaster": "^2.0.0",


### PR DESCRIPTION
### Requirements

*Fixing deployment changes

### Description of the Change

Since for the core services, there are no deployment accounts field, we have to put a check and fetch the default data

### Benefits

Build won't fail during stack creation

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
