### PR TITLE
Fixed incorrect asset arn and incorrect java api template swagger

### DIFF
--- a/builds/jazz-build-module/aws-apigateway-module.groovy
+++ b/builds/jazz-build-module/aws-apigateway-module.groovy
@@ -53,8 +53,8 @@ def FindUserDefinedIntegrationSpec(filePath) {
       }
     }
   } catch (ex) {
-    echo " RemoveUserDefinedIntegrationSpec :::: Error occurred" + ex.getMessage()
-    error " RemoveUserDefinedIntegrationSpec :::: Error occurred" + ex.getMessage()
+    echo " FindUserDefinedIntegrationSpec :::: Error occurred " + ex.getMessage()
+    error " FindUserDefinedIntegrationSpec :::: Error occurred " + ex.getMessage()
   }
 }
 

--- a/builds/jenkins-build-pack-api/Jenkinsfile
+++ b/builds/jenkins-build-pack-api/Jenkinsfile
@@ -287,7 +287,7 @@ node() {
                   endpointUrl = "https://${apiHostName}/${current_environment}/${environment_logical_id}/${config['domain']}/${config['service']}"
                 }
 
-                def apiArns = getSwaggerResourceARNs(aws_api_id, environment_logical_id, "aws")
+                def apiArns = getSwaggerResourceARNs(aws_api_id, current_environment, "aws")
                 if (apiArns) {
                   for (arn in apiArns) {
                     events.sendCompletedEvent('CREATE_ASSET', null, utilModule.generateAssetMap("aws", arn, "apigateway", config), environment_logical_id);

--- a/templates/api-template-java/swagger/swagger.json
+++ b/templates/api-template-java/swagger/swagger.json
@@ -12,8 +12,8 @@
   ],
   "paths": {
     "/{service_name}": {
-      "operationId": "{operationId}",
       "options": {
+        "operationId": "{operationId}",
         "description": "CORS Support",
         "consumes": [
           "application/json"


### PR DESCRIPTION
this PR fixes the below two bugs:

1. The swagger file in the java api template had a wrong structure. This was causing errors when a java api was created
2. For APIs created in dev environment, incorrect arn was being stored in the asset table. 

