### PR TITLE
Bug Fix on Multi-Account api delete build packs

### DIFF
--- a/builds/delete-serverless-service-build-pack/Jenkinsfile
+++ b/builds/delete-serverless-service-build-pack/Jenkinsfile
@@ -663,8 +663,9 @@ def getApiId(stage) {
  * @return  api Id
  */
 def cleanUpApiDocs(stage) {
+	def primaryAccount = utilModule.getAccountInfoPrimary()
 	withCredentials([
-		[$class: 'AmazonWebServicesCredentialsBinding',  credentialsId: service_config.credentialId]
+		[$class: 'AmazonWebServicesCredentialsBinding',  credentialsId: primaryAccount.CREDENTIAL_ID]
 	]) {
 		try {
 			def apiRootFolder = getApiDocsFolder(stage)


### PR DESCRIPTION
### Description of the Change

The Apidocs which are stored on primary accounts, should be cleaned while deleting the api service of non-primary Accounts.

Updated primary account credential Id for cleaning the Apidocs.
### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
