### PR TITLE
SLS Impl: Including asset type filter in logs service.

### DIFF
--- a/core/jazz_logs/config/dev-config.json
+++ b/core/jazz_logs/config/dev-config.json
@@ -4,7 +4,21 @@
   "DEFAULT_TIME_IN_DAYS": 7,
   "VALID_ENVIRONMENTS": ["prod", "stg", "dev"],
   "VALID_CATEGORIES": ["api", "function"],
-  "VALID_ASSET_TYPES": ["lambda", "apigateway"],
+  "VALID_ASSET_TYPES": [
+    "lambda",
+    "apigateway",
+    "cloudfront",
+    "s3",
+    "dynamodb",
+    "cloudwatch_event",
+    "swagger_url",
+    "endpoint_url",
+    "dynamodb_stream",
+    "iam_role",
+    "sqs",
+    "kinesis_stream",
+    "apigee_proxy"
+  ],
   "ASSET_INDEX_MAP":[{
     "asset_type": "lambda",
     "es_index": ["applicationlogs"]

--- a/core/jazz_logs/config/dev-config.json
+++ b/core/jazz_logs/config/dev-config.json
@@ -4,7 +4,14 @@
   "DEFAULT_TIME_IN_DAYS": 7,
   "VALID_ENVIRONMENTS": ["prod", "stg", "dev"],
   "VALID_CATEGORIES": ["api", "function"],
-  "VALID_ASSET_TYPES": ["apilogs", "applicationlogs"],
+  "VALID_ASSET_TYPES": ["lambda", "apigateway"],
+  "ASSET_INDEX_MAP":[{
+    "asset_type": "lambda",
+    "es_index": ["applicationlogs"]
+  }, {
+    "asset_type": "apigateway",
+    "es_index": ["apilogs"]
+  }],
   "VALID_LOGTYPES": ["warn", "error", "info", "verbose", "debug", "fatal", "trace", "off", "all"],
   "ENV_PREFIX": "{env-prefix}",
   "LOG_LEVELS": [{

--- a/core/jazz_logs/config/dev-config.json
+++ b/core/jazz_logs/config/dev-config.json
@@ -2,8 +2,9 @@
 	"BASE_URL" :"https://{inst_elastic_search_hostname}/",
 	"DEFAULT_SIZE" : 1000,
 	"DEFAULT_TIME_IN_DAYS" : 7,
-	"VALID_ENVIRONMENTS" : ["prod", "stg", "dev"],
-	"VALID_CATEGORIES" : ["api", "function"],
+    "VALID_ENVIRONMENTS" : ["prod", "stg", "dev"],
+    "VALID_CATEGORIES" : ["api", "function"],
+    "VALID_ASSET_TYPES" : ["apilogs", "applicationlogs"],
 	"VALID_LOGTYPES" : ["warn", "error", "info", "verbose", "debug", "fatal", "trace", "off", "all"],
 	"ENV_PREFIX" : "{env-prefix}",
 	"LOG_LEVELS": [

--- a/core/jazz_logs/config/dev-config.json
+++ b/core/jazz_logs/config/dev-config.json
@@ -1,48 +1,47 @@
 {
-	"BASE_URL" :"https://{inst_elastic_search_hostname}/",
-	"DEFAULT_SIZE" : 1000,
-	"DEFAULT_TIME_IN_DAYS" : 7,
-    "VALID_ENVIRONMENTS" : ["prod", "stg", "dev"],
-    "VALID_CATEGORIES" : ["api", "function"],
-    "VALID_ASSET_TYPES" : ["apilogs", "applicationlogs"],
-	"VALID_LOGTYPES" : ["warn", "error", "info", "verbose", "debug", "fatal", "trace", "off", "all"],
-	"ENV_PREFIX" : "{env-prefix}",
-	"LOG_LEVELS": [
-        {
-            "Level": 0,
-            "Type": "off"
-        },
-        {
-            "Level": 1,
-            "Type": "fatal"
-        },
-        {
-            "Level": 2,
-            "Type": "error"
-        },
-        {
-            "Level": 3,
-            "Type": "warn"
-        },
-        {
-            "Level": 4,
-            "Type": "info"
-        },
-        {
-            "Level": 5,
-            "Type": "debug"
-        },
-        {
-            "Level": 6,
-            "Type": "trace"
-        },
-        {
-            "Level": 7,
-            "Type": "verbose"
-        },
-        {
-            "Level": 8,
-            "Type": "all"
-        }
-    ]
+  "BASE_URL": "https://{inst_elastic_search_hostname}/",
+  "DEFAULT_SIZE": 1000,
+  "DEFAULT_TIME_IN_DAYS": 7,
+  "VALID_ENVIRONMENTS": ["prod", "stg", "dev"],
+  "VALID_CATEGORIES": ["api", "function"],
+  "VALID_ASSET_TYPES": ["apilogs", "applicationlogs"],
+  "VALID_LOGTYPES": ["warn", "error", "info", "verbose", "debug", "fatal", "trace", "off", "all"],
+  "ENV_PREFIX": "{env-prefix}",
+  "LOG_LEVELS": [{
+      "Level": 0,
+      "Type": "off"
+    },
+    {
+      "Level": 1,
+      "Type": "fatal"
+    },
+    {
+      "Level": 2,
+      "Type": "error"
+    },
+    {
+      "Level": 3,
+      "Type": "warn"
+    },
+    {
+      "Level": 4,
+      "Type": "info"
+    },
+    {
+      "Level": 5,
+      "Type": "debug"
+    },
+    {
+      "Level": 6,
+      "Type": "trace"
+    },
+    {
+      "Level": 7,
+      "Type": "verbose"
+    },
+    {
+      "Level": 8,
+      "Type": "all"
+    }
+  ]
 }

--- a/core/jazz_logs/config/prod-config.json
+++ b/core/jazz_logs/config/prod-config.json
@@ -4,7 +4,14 @@
   "DEFAULT_TIME_IN_DAYS": 7,
   "VALID_ENVIRONMENTS": ["prod", "stg", "dev"],
   "VALID_CATEGORIES": ["api", "function"],
-  "VALID_ASSET_TYPES": ["apilogs", "applicationlogs"],
+  "VALID_ASSET_TYPES": ["lambda", "apigateway"],
+  "ASSET_INDEX_MAP":[{
+    "asset_type": "lambda",
+    "es_index": ["applicationlogs"]
+  }, {
+    "asset_type": "apigateway",
+    "es_index": ["apilogs"]
+  }],
   "VALID_LOGTYPES": ["warn", "error", "info", "verbose", "debug", "fatal", "trace", "off", "all"],
   "ENV_PREFIX": "{env-prefix}",
   "LOG_LEVELS": [{

--- a/core/jazz_logs/config/prod-config.json
+++ b/core/jazz_logs/config/prod-config.json
@@ -4,8 +4,22 @@
   "DEFAULT_TIME_IN_DAYS": 7,
   "VALID_ENVIRONMENTS": ["prod", "stg", "dev"],
   "VALID_CATEGORIES": ["api", "function"],
-  "VALID_ASSET_TYPES": ["lambda", "apigateway"],
-  "ASSET_INDEX_MAP":[{
+  "VALID_ASSET_TYPES": [
+    "lambda",
+    "apigateway",
+    "cloudfront",
+    "s3",
+    "dynamodb",
+    "cloudwatch_event",
+    "swagger_url",
+    "endpoint_url",
+    "dynamodb_stream",
+    "iam_role",
+    "sqs",
+    "kinesis_stream",
+    "apigee_proxy"
+  ],
+  "ASSET_INDEX_MAP": [{
     "asset_type": "lambda",
     "es_index": ["applicationlogs"]
   }, {

--- a/core/jazz_logs/config/prod-config.json
+++ b/core/jazz_logs/config/prod-config.json
@@ -2,8 +2,9 @@
 	"BASE_URL" :"https://{inst_elastic_search_hostname}/",
 	"DEFAULT_SIZE" : 1000,
 	"DEFAULT_TIME_IN_DAYS" : 7,
-	"VALID_ENVIRONMENTS" : ["prod", "stg", "dev"],
-	"VALID_CATEGORIES" : ["api", "function"],
+    "VALID_ENVIRONMENTS" : ["prod", "stg", "dev"],
+    "VALID_CATEGORIES" : ["api", "function"],
+    "VALID_ASSET_TYPES" : ["apilogs", "applicationlogs"],
 	"VALID_LOGTYPES" : ["warn", "error", "info", "verbose", "debug", "fatal", "trace", "off", "all"],
 	"ENV_PREFIX" : "{env-prefix}",
 	"LOG_LEVELS": [

--- a/core/jazz_logs/config/prod-config.json
+++ b/core/jazz_logs/config/prod-config.json
@@ -1,48 +1,47 @@
 {
-	"BASE_URL" :"https://{inst_elastic_search_hostname}/",
-	"DEFAULT_SIZE" : 1000,
-	"DEFAULT_TIME_IN_DAYS" : 7,
-    "VALID_ENVIRONMENTS" : ["prod", "stg", "dev"],
-    "VALID_CATEGORIES" : ["api", "function"],
-    "VALID_ASSET_TYPES" : ["apilogs", "applicationlogs"],
-	"VALID_LOGTYPES" : ["warn", "error", "info", "verbose", "debug", "fatal", "trace", "off", "all"],
-	"ENV_PREFIX" : "{env-prefix}",
-	"LOG_LEVELS": [
-        {
-            "Level": 0,
-            "Type": "off"
-        },
-        {
-            "Level": 1,
-            "Type": "fatal"
-        },
-        {
-            "Level": 2,
-            "Type": "error"
-        },
-        {
-            "Level": 3,
-            "Type": "warn"
-        },
-        {
-            "Level": 4,
-            "Type": "info"
-        },
-        {
-            "Level": 5,
-            "Type": "debug"
-        },
-        {
-            "Level": 6,
-            "Type": "trace"
-        },
-        {
-            "Level": 7,
-            "Type": "verbose"
-        },
-        {
-            "Level": 8,
-            "Type": "all"
-        }
-    ]
+  "BASE_URL": "https://{inst_elastic_search_hostname}/",
+  "DEFAULT_SIZE": 1000,
+  "DEFAULT_TIME_IN_DAYS": 7,
+  "VALID_ENVIRONMENTS": ["prod", "stg", "dev"],
+  "VALID_CATEGORIES": ["api", "function"],
+  "VALID_ASSET_TYPES": ["apilogs", "applicationlogs"],
+  "VALID_LOGTYPES": ["warn", "error", "info", "verbose", "debug", "fatal", "trace", "off", "all"],
+  "ENV_PREFIX": "{env-prefix}",
+  "LOG_LEVELS": [{
+      "Level": 0,
+      "Type": "off"
+    },
+    {
+      "Level": 1,
+      "Type": "fatal"
+    },
+    {
+      "Level": 2,
+      "Type": "error"
+    },
+    {
+      "Level": 3,
+      "Type": "warn"
+    },
+    {
+      "Level": 4,
+      "Type": "info"
+    },
+    {
+      "Level": 5,
+      "Type": "debug"
+    },
+    {
+      "Level": 6,
+      "Type": "trace"
+    },
+    {
+      "Level": 7,
+      "Type": "verbose"
+    },
+    {
+      "Level": 8,
+      "Type": "all"
+    }
+  ]
 }

--- a/core/jazz_logs/config/stg-config.json
+++ b/core/jazz_logs/config/stg-config.json
@@ -4,7 +4,21 @@
   "DEFAULT_TIME_IN_DAYS": 7,
   "VALID_ENVIRONMENTS": ["prod", "stg", "dev"],
   "VALID_CATEGORIES": ["api", "function"],
-  "VALID_ASSET_TYPES": ["lambda", "apigateway"],
+  "VALID_ASSET_TYPES": [
+    "lambda",
+    "apigateway",
+    "cloudfront",
+    "s3",
+    "dynamodb",
+    "cloudwatch_event",
+    "swagger_url",
+    "endpoint_url",
+    "dynamodb_stream",
+    "iam_role",
+    "sqs",
+    "kinesis_stream",
+    "apigee_proxy"
+  ],
   "ASSET_INDEX_MAP":[{
     "asset_type": "lambda",
     "es_index": ["applicationlogs"]

--- a/core/jazz_logs/config/stg-config.json
+++ b/core/jazz_logs/config/stg-config.json
@@ -4,7 +4,14 @@
   "DEFAULT_TIME_IN_DAYS": 7,
   "VALID_ENVIRONMENTS": ["prod", "stg", "dev"],
   "VALID_CATEGORIES": ["api", "function"],
-  "VALID_ASSET_TYPES": ["apilogs", "applicationlogs"],
+  "VALID_ASSET_TYPES": ["lambda", "apigateway"],
+  "ASSET_INDEX_MAP":[{
+    "asset_type": "lambda",
+    "es_index": ["applicationlogs"]
+  }, {
+    "asset_type": "apigateway",
+    "es_index": ["apilogs"]
+  }],
   "VALID_LOGTYPES": ["warn", "error", "info", "verbose", "debug", "fatal", "trace", "off", "all"],
   "ENV_PREFIX": "{env-prefix}",
   "LOG_LEVELS": [{

--- a/core/jazz_logs/config/stg-config.json
+++ b/core/jazz_logs/config/stg-config.json
@@ -2,8 +2,9 @@
 	"BASE_URL" :"https://{inst_elastic_search_hostname}/",
 	"DEFAULT_SIZE" : 1000,
 	"DEFAULT_TIME_IN_DAYS" : 7,
-	"VALID_ENVIRONMENTS" : ["prod", "stg", "dev"],
-	"VALID_CATEGORIES" : ["api", "function"],
+    "VALID_ENVIRONMENTS" : ["prod", "stg", "dev"],
+    "VALID_CATEGORIES" : ["api", "function"],
+    "VALID_ASSET_TYPES" : ["apilogs", "applicationlogs"],
 	"VALID_LOGTYPES" : ["warn", "error", "info", "verbose", "debug", "fatal", "trace", "off", "all"],
 	"ENV_PREFIX" : "{env-prefix}",
 	"LOG_LEVELS": [

--- a/core/jazz_logs/config/stg-config.json
+++ b/core/jazz_logs/config/stg-config.json
@@ -1,48 +1,47 @@
 {
-	"BASE_URL" :"https://{inst_elastic_search_hostname}/",
-	"DEFAULT_SIZE" : 1000,
-	"DEFAULT_TIME_IN_DAYS" : 7,
-    "VALID_ENVIRONMENTS" : ["prod", "stg", "dev"],
-    "VALID_CATEGORIES" : ["api", "function"],
-    "VALID_ASSET_TYPES" : ["apilogs", "applicationlogs"],
-	"VALID_LOGTYPES" : ["warn", "error", "info", "verbose", "debug", "fatal", "trace", "off", "all"],
-	"ENV_PREFIX" : "{env-prefix}",
-	"LOG_LEVELS": [
-        {
-            "Level": 0,
-            "Type": "off"
-        },
-        {
-            "Level": 1,
-            "Type": "fatal"
-        },
-        {
-            "Level": 2,
-            "Type": "error"
-        },
-        {
-            "Level": 3,
-            "Type": "warn"
-        },
-        {
-            "Level": 4,
-            "Type": "info"
-        },
-        {
-            "Level": 5,
-            "Type": "debug"
-        },
-        {
-            "Level": 6,
-            "Type": "trace"
-        },
-        {
-            "Level": 7,
-            "Type": "verbose"
-        },
-        {
-            "Level": 8,
-            "Type": "all"
-        }
-    ]
+  "BASE_URL": "https://{inst_elastic_search_hostname}/",
+  "DEFAULT_SIZE": 1000,
+  "DEFAULT_TIME_IN_DAYS": 7,
+  "VALID_ENVIRONMENTS": ["prod", "stg", "dev"],
+  "VALID_CATEGORIES": ["api", "function"],
+  "VALID_ASSET_TYPES": ["apilogs", "applicationlogs"],
+  "VALID_LOGTYPES": ["warn", "error", "info", "verbose", "debug", "fatal", "trace", "off", "all"],
+  "ENV_PREFIX": "{env-prefix}",
+  "LOG_LEVELS": [{
+      "Level": 0,
+      "Type": "off"
+    },
+    {
+      "Level": 1,
+      "Type": "fatal"
+    },
+    {
+      "Level": 2,
+      "Type": "error"
+    },
+    {
+      "Level": 3,
+      "Type": "warn"
+    },
+    {
+      "Level": 4,
+      "Type": "info"
+    },
+    {
+      "Level": 5,
+      "Type": "debug"
+    },
+    {
+      "Level": 6,
+      "Type": "trace"
+    },
+    {
+      "Level": 7,
+      "Type": "verbose"
+    },
+    {
+      "Level": 8,
+      "Type": "all"
+    }
+  ]
 }

--- a/core/jazz_logs/config/test-config.json
+++ b/core/jazz_logs/config/test-config.json
@@ -1,10 +1,10 @@
 {
-	"BASE_URL" :"https://{inst_elastic_search_hostname}/",
-	"DEFAULT_SIZE" : 1000,
-	"DEFAULT_TIME_IN_DAYS" : 7,
-	"VALID_ENVIRONMENTS" : ["prod", "stg", "dev", "test"],
-	"VALID_CATEGORIES" : ["api", "function"],
-	"VALID_ASSET_TYPES" : ["apilogs", "applicationlogs"],
-	"VALID_LOGTYPES" : ["warn", "error", "info", "verbose", "debug"],
-	"ENV_PREFIX" : "bA11r00m-dAnCe"
+  "BASE_URL": "https://{inst_elastic_search_hostname}/",
+  "DEFAULT_SIZE": 1000,
+  "DEFAULT_TIME_IN_DAYS": 7,
+  "VALID_ENVIRONMENTS": ["prod", "stg", "dev", "test"],
+  "VALID_CATEGORIES": ["api", "function"],
+  "VALID_ASSET_TYPES": ["apilogs", "applicationlogs"],
+  "VALID_LOGTYPES": ["warn", "error", "info", "verbose", "debug"],
+  "ENV_PREFIX": "bA11r00m-dAnCe"
 }

--- a/core/jazz_logs/config/test-config.json
+++ b/core/jazz_logs/config/test-config.json
@@ -4,7 +4,14 @@
   "DEFAULT_TIME_IN_DAYS": 7,
   "VALID_ENVIRONMENTS": ["prod", "stg", "dev", "test"],
   "VALID_CATEGORIES": ["api", "function"],
-  "VALID_ASSET_TYPES": ["apilogs", "applicationlogs"],
+  "VALID_ASSET_TYPES": ["lambda", "apigateway"],
+  "ASSET_INDEX_MAP":[{
+    "asset_type": "lambda",
+    "es_index": ["applicationlogs"]
+  }, {
+    "asset_type": "apigateway",
+    "es_index": ["apilogs"]
+  }],
   "VALID_LOGTYPES": ["warn", "error", "info", "verbose", "debug"],
   "ENV_PREFIX": "bA11r00m-dAnCe",
   "LOG_LEVELS": [{

--- a/core/jazz_logs/config/test-config.json
+++ b/core/jazz_logs/config/test-config.json
@@ -4,6 +4,7 @@
 	"DEFAULT_TIME_IN_DAYS" : 7,
 	"VALID_ENVIRONMENTS" : ["prod", "stg", "dev", "test"],
 	"VALID_CATEGORIES" : ["api", "function"],
+	"VALID_ASSET_TYPES" : ["apilogs", "applicationlogs"],
 	"VALID_LOGTYPES" : ["warn", "error", "info", "verbose", "debug"],
 	"ENV_PREFIX" : "bA11r00m-dAnCe"
 }

--- a/core/jazz_logs/config/test-config.json
+++ b/core/jazz_logs/config/test-config.json
@@ -6,5 +6,42 @@
   "VALID_CATEGORIES": ["api", "function"],
   "VALID_ASSET_TYPES": ["apilogs", "applicationlogs"],
   "VALID_LOGTYPES": ["warn", "error", "info", "verbose", "debug"],
-  "ENV_PREFIX": "bA11r00m-dAnCe"
+  "ENV_PREFIX": "bA11r00m-dAnCe",
+  "LOG_LEVELS": [{
+      "Level": 0,
+      "Type": "off"
+    },
+    {
+      "Level": 1,
+      "Type": "fatal"
+    },
+    {
+      "Level": 2,
+      "Type": "error"
+    },
+    {
+      "Level": 3,
+      "Type": "warn"
+    },
+    {
+      "Level": 4,
+      "Type": "info"
+    },
+    {
+      "Level": 5,
+      "Type": "debug"
+    },
+    {
+      "Level": 6,
+      "Type": "trace"
+    },
+    {
+      "Level": 7,
+      "Type": "verbose"
+    },
+    {
+      "Level": 8,
+      "Type": "all"
+    }
+  ]
 }

--- a/core/jazz_logs/index.js
+++ b/core/jazz_logs/index.js
@@ -112,8 +112,16 @@ module.exports.handler = (event, context, cb) => {
 			logger.info("QueryObj: " + JSON.stringify(querys));
 			var servCategory = [];
 			if (assetType) {
-				let indexMap = config.ASSET_INDEX_MAP.filter(assetObj => (assetObj.asset_type === assetType))
+				let indexMap = config.ASSET_INDEX_MAP.filter(assetObj => (assetObj.asset_type === assetType));
+				if (indexMap.length) {
 					servCategory = indexMap[0].es_index;
+				} else {
+					let response = {
+						count: 0,
+						logs: []
+					};
+					return cb(null, responseObj(response, event.body));
+				}
 			}
 
 			var req = utils.requestLoad;
@@ -146,11 +154,8 @@ module.exports.handler = (event, context, cb) => {
 						utils.responseModel.count = count;
 						utils.responseModel.logs = logs;
 
-						// TODO: Remove as this is hack for UI fix
-						var ret = { "data": utils.responseModel };
-
 						logger.info('Output :' + JSON.stringify(utils.responseModel));
-						return cb(null, responseObj(ret, event.body));
+						return cb(null, responseObj(utils.responseModel, event.body));
 
 					} else {
 						var error_message = 'Unknown error occured';

--- a/core/jazz_logs/index.js
+++ b/core/jazz_logs/index.js
@@ -110,8 +110,12 @@ module.exports.handler = (event, context, cb) => {
 			}
 
 			logger.info("QueryObj: " + JSON.stringify(querys));
+			var servCategory = [];
+			if (assetType) {
+				let indexMap = config.ASSET_INDEX_MAP.filter(assetObj => (assetObj.asset_type === assetType))
+					servCategory = indexMap[0].es_index;
+			}
 
-			var servCategory = assetType ? [`${assetType}`] : [];
 			var req = utils.requestLoad;
 			req.url = config.BASE_URL + "/_plugin/kibana/elasticsearch/_msearch";
 			req.body = setRequestBody(servCategory, env, querys, startTime, endTime, size, page);

--- a/core/jazz_logs/index.js
+++ b/core/jazz_logs/index.js
@@ -67,10 +67,15 @@ module.exports.handler = (event, context, cb) => {
 				return cb(JSON.stringify(errorHandler.throwInputValidationError("Only following values are allowed for category - " + config.VALID_CATEGORIES.join(", "))));
 			}
 
+			if (event.body.asset_type && config.VALID_ASSET_TYPES.indexOf(event.body.asset_type) === -1) {
+				return cb(JSON.stringify(errorHandler.throwInputValidationError("Only following values are allowed for asset type - " + config.VALID_ASSET_TYPES.join(", "))));
+			}
+
 			var service = event.body.service,
 				domain = event.body.domain,
 				env = event.body.environment.toLowerCase(),
 				categoryType = event.body.category.toLowerCase(),
+				assetType = event.body.asset_type ? event.body.asset_type.toLowerCase() : "",
 				logType = event.body.type.toUpperCase(),
 				page = event.body.offset ? event.body.offset : 0,
 				startTime = event.body.start_time ? event.body.start_time : utils.setStartDate(config.DEFAULT_TIME_IN_DAYS),
@@ -106,14 +111,7 @@ module.exports.handler = (event, context, cb) => {
 
 			logger.info("QueryObj: " + JSON.stringify(querys));
 
-			var servCategory = [];
-
-			if (categoryType.toLowerCase() == 'api') {
-				servCategory = ["apilogs", "applicationlogs"];
-			} else if (categoryType.toLowerCase() == 'function') {
-				servCategory = ["applicationlogs"];
-			}
-
+			var servCategory = assetType ? [`${assetType}`] : [];
 			var req = utils.requestLoad;
 			req.url = config.BASE_URL + "/_plugin/kibana/elasticsearch/_msearch";
 			req.body = setRequestBody(servCategory, env, querys, startTime, endTime, size, page);

--- a/core/jazz_logs/package.json
+++ b/core/jazz_logs/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "author": [],
   "scripts": {
-    "test": "mocha"
+    "test": "nyc --reporter=html --reporter=text mocha"
   },
   "dependencies": {
     "request": "*",

--- a/core/jazz_logs/package.json
+++ b/core/jazz_logs/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "author": [],
   "scripts": {
-    "test": "nyc --reporter=html --reporter=text mocha"
+    "test": "mocha"
   },
   "dependencies": {
     "request": "*",

--- a/core/jazz_logs/swagger/swagger.json
+++ b/core/jazz_logs/swagger/swagger.json
@@ -438,7 +438,18 @@
         "asset_type": {
           "enum": [
             "lambda",
-            "apigateway"
+            "apigateway",
+            "cloudfront",
+            "s3",
+            "dynamodb",
+            "cloudwatch_event",
+            "swagger_url",
+            "endpoint_url",
+            "dynamodb_stream",
+            "iam_role",
+            "sqs",
+            "kinesis_stream",
+            "apigee_proxy"
           ],
           "type": "string",
           "description": "Asset type for which the logs should be fetched."

--- a/core/jazz_logs/swagger/swagger.json
+++ b/core/jazz_logs/swagger/swagger.json
@@ -97,17 +97,15 @@
       },
       "post": {
         "description": "Post method swagger for Node template",
-        "parameters": [
-          {
-            "name": "param",
-            "in": "body",
-            "description": "post body parameter.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/InputObj"
-            }
+        "parameters": [{
+          "name": "param",
+          "in": "body",
+          "description": "post body parameter.",
+          "required": true,
+          "schema": {
+            "$ref": "#/definitions/InputObj"
           }
-        ],
+        }],
         "consumes": [
           "application/json",
           "application/x-www-form-urlencoded"
@@ -409,7 +407,7 @@
         "service",
         "domain",
         "environment",
-		"category"
+        "category"
       ],
       "properties": {
         "service": {
@@ -429,22 +427,30 @@
           "type": "string",
           "description": "Environment in which the service is deployed"
         },
-		"category": {
-		  "enum": [
+        "category": {
+          "enum": [
             "api",
             "function"
           ],
           "type": "string",
           "description": "Service type"
         },
-		"start_time": {
+        "asset_type": {
+          "enum": [
+            "apilogs",
+            "applicationlogs"
+          ],
           "type": "string",
-		  "format": "date-time",
+          "description": "Asset type for which the logs should be fetched."
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time",
           "description": "start time"
         },
         "end_time": {
           "type": "string",
-		  "format": "date-time",
+          "format": "date-time",
           "description": "end time"
         },
         "size": {
@@ -455,16 +461,16 @@
           "type": "number",
           "description": "Starting record number"
         },
-		"type": {
-		  "enum": [
-		    "warn",
-			"error",
-		    "info",
-		    "debug"		    
-		  ],
-		  "type": "string",
-		  "description": "log type"
-	    }
+        "type": {
+          "enum": [
+            "warn",
+            "error",
+            "info",
+            "debug"
+          ],
+          "type": "string",
+          "description": "log type"
+        }
       }
     },
     "OutputObj": {
@@ -480,7 +486,7 @@
                 "type": "string",
                 "description": "request id of the log message"
               },
-			  "timestamp": {
+              "timestamp": {
                 "type": "string",
                 "description": "time of the log message"
               },
@@ -489,12 +495,12 @@
                 "description": "log message"
               },
               "type": {
-			    "enum": [
-				 "debug",
-				 "info",
-				 "warn",
-				 "error"
-				],
+                "enum": [
+                  "debug",
+                  "info",
+                  "warn",
+                  "error"
+                ],
                 "type": "string",
                 "description": "log type"
               }

--- a/core/jazz_logs/swagger/swagger.json
+++ b/core/jazz_logs/swagger/swagger.json
@@ -437,8 +437,8 @@
         },
         "asset_type": {
           "enum": [
-            "apilogs",
-            "applicationlogs"
+            "lambda",
+            "apigateway"
           ],
           "type": "string",
           "description": "Asset type for which the logs should be fetched."

--- a/core/jazz_logs/test/test.js
+++ b/core/jazz_logs/test/test.js
@@ -237,7 +237,7 @@ describe('platform_logs', function() {
 
   /*
   * Given event.body.asset_type that is listed as valid in config, handler() should not inform of asset_type exception
-  * @param{object} event -> event.body.asset_type is either apilogs or applicationlogs, not invalidlogs or other
+  * @param{object} event -> event.body.asset_type can be any whitelisted asset(apigateway, lambda, s3 etc), not invalidasset or other
   * @params{object, function} aws context, and callback function as described in beforeEach
   * @returns{string} error message indicating a bad request was made
   */

--- a/core/jazz_logs/test/test.js
+++ b/core/jazz_logs/test/test.js
@@ -65,7 +65,7 @@ describe('platform_logs', function() {
         "category": "api",
         "offset": "44",
         "type" : "debug",
-        "asset_type": "apilogs"
+        "asset_type": "lambda"
       },
       "method":"POST",
       "path" : {},
@@ -244,7 +244,7 @@ describe('platform_logs', function() {
  it("should allow only apilogs and applicationlogs to be listed as the asset type", () => {
   errorMessage = "Only following values are allowed for asset type - ";
   errorType = "BadRequest";
-  var invalidArray = ["apilogs", "applicationlogs", "invalidlogs"];
+  var invalidArray = ["lambda", "apigateway", "invalidasset"];
   var acceptCount = 3;
   //only have 2 of the values listed be acceptable
   for(i in invalidArray){

--- a/core/jazz_logs/test/test.js
+++ b/core/jazz_logs/test/test.js
@@ -64,7 +64,8 @@ describe('platform_logs', function() {
         "domain": "bA11r00m",
         "category": "api",
         "offset": "44",
-        "type" : "debug"
+        "type" : "debug",
+        "asset_type": "apilogs"
       },
       "method":"POST",
       "path" : {},
@@ -235,6 +236,26 @@ describe('platform_logs', function() {
   });
 
   /*
+  * Given event.body.asset_type that is listed as valid in config, handler() should not inform of asset_type exception
+  * @param{object} event -> event.body.asset_type is either apilogs or applicationlogs, not invalidlogs or other
+  * @params{object, function} aws context, and callback function as described in beforeEach
+  * @returns{string} error message indicating a bad request was made
+  */
+ it("should allow only apilogs and applicationlogs to be listed as the asset type", () => {
+  errorMessage = "Only following values are allowed for asset type - ";
+  errorType = "BadRequest";
+  var invalidArray = ["apilogs", "applicationlogs", "invalidlogs"];
+  var acceptCount = 3;
+  //only have 2 of the values listed be acceptable
+  for(i in invalidArray){
+    if(inputValidation("body", "asset_type", invalidArray[i], errorMessage, errorType)){
+      acceptCount--;
+    }
+  }
+  assert.isTrue(acceptCount == 2);
+});
+
+  /*
   * Given an event.body.type not listed as valid through config or is not given, handler() indicates type isn't valid
   * @param{object} event -> event.body.type = falsy or is not listed as valid in config file
   * @params{object, function} aws context, and callback function as described in beforeEach
@@ -295,7 +316,7 @@ describe('platform_logs', function() {
     assert.isTrue(allChecks);
   });
   */
- 
+
   /*
   * Given a 200 response, handler() reveals content of returned response
   * @param {object, object, function} default event, context, and callback as described in beforeEach


### PR DESCRIPTION
### Requirements

* Changes to /logs API to get logs based on the asset Type Filter 

### Description of the Change

* Including "asset_type" as optional param and valid asset types are mentioned in the config files.

### Benefits

Logs will be fetched for the requested asset_type(api logs or function logs)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
