### PR TITLE
Remove S3 environment bucket policy statement on web environment delete

### DIFF
--- a/builds/delete-serverless-service-build-pack/Jenkinsfile
+++ b/builds/delete-serverless-service-build-pack/Jenkinsfile
@@ -846,7 +846,7 @@ def cleanupS3BucketPolicy(stage, assetInfo) {
 			policyObjectUpdated.Id = policyObject.Id
 			def statements = []
 			for (items in policyObject.Statement) {
-				if ((items.Sid != "list-${assetInfo['asset_name']}")) {
+				if (items.Resource != "arn:aws:s3:::${assetInfo['asset_info']}/*") {
 					def copy = [:]
 					copy.putAll(items)
 					statements.add(copy)


### PR DESCRIPTION
### Description of the Change

- On deletion of a web service environment, remove the policy statement from its parent bucket policy. 
- The `s3:ListBucket` policy statement is no longer removed.

### Benefits

- Bucket policy mirrors environments.
- Less likely to hit bucket policy KB limit.

### Possible Drawbacks

N/A

### Applicable Issues

N/A
