### PR TITLE
Fix deletion of CloudFront Distributions on Tear Down Resources

### DIFF
--- a/builds/jenkins-delete-resources/Jenkinsfile
+++ b/builds/jenkins-delete-resources/Jenkinsfile
@@ -79,7 +79,7 @@ node {
           processS3Buckets(s3Buckets)
           deletePrimaryAccountPolicy(accountID, finalAccounts);
           deleteUserServices(regionAws);
-          deleteStackCloudFrontDists(regionAws)
+          deleteStackCloudFrontDists(cloudFront)
         }
       }
       if ( !isPrimaryAccount ) {
@@ -411,14 +411,15 @@ def deleteStack(stackName, regionAws) {
 /**
 * Process CloudFront Deletion
 **/
-def deleteStackCloudFrontDists(regionAws) {
+def deleteStackCloudFrontDists(cloudFront) {
   try {
     def output = sh(script:"aws cloudfront list-distributions --region ${regionAws}", returnStdout: true)
     def stacks = parseJson(output)
     if(stacks.size() > 0 ){
       for(distribution in stacks['DistributionList']['Items']){
         def id = distribution['Origins']['Items'][0]['Id']
-        if(id.startsWith(instance_prefix)){
+        def originAccess_identity = distribution['Origins']['Items'][0]['S3OriginConfig']['OriginAccessIdentity']
+        if(cloudFront.CLOUDFRONT_ORIGIN_ID == originAccess_identity  && id.startsWith(instance_prefix)){
             echo "Processing Deletion of CloudFront Distribution Id ${id}"
             checkAndDeleteCloudFront(distribution['Id'])
         }

--- a/builds/jenkins-delete-resources/Jenkinsfile
+++ b/builds/jenkins-delete-resources/Jenkinsfile
@@ -413,13 +413,14 @@ def deleteStack(stackName, regionAws) {
 **/
 def deleteStackCloudFrontDists(cloudFront) {
   try {
-    def output = sh(script:"aws cloudfront list-distributions --region ${regionAws}", returnStdout: true)
+    def output = sh(script:"aws cloudfront list-distributions", returnStdout: true)
     def stacks = parseJson(output)
     if(stacks.size() > 0 ){
       for(distribution in stacks['DistributionList']['Items']){
         def id = distribution['Origins']['Items'][0]['Id']
         def originAccess_identity = distribution['Origins']['Items'][0]['S3OriginConfig']['OriginAccessIdentity']
-        if(cloudFront.CLOUDFRONT_ORIGIN_ID == originAccess_identity  && id.startsWith(instance_prefix)){
+        def accountOriginAccessId = parseOriginAccessIdentity(cloudFront.CLOUDFRONT_ORIGIN_ID)
+        if(accountOriginAccessId == originAccess_identity  && id.startsWith(instance_prefix)){
             echo "Processing Deletion of CloudFront Distribution Id ${id}"
             checkAndDeleteCloudFront(distribution['Id'])
         }
@@ -428,6 +429,17 @@ def deleteStackCloudFrontDists(cloudFront) {
   } catch (ex) {
     echo "${ex.message}"
   }
+}
+
+def parseOriginAccessIdentity(id){
+  def parsed_id = ""
+  if(id.contains('/')){
+    parsed_id = identity
+  } else {
+     parsed_id = "origin-access-identity/cloudfront/${id}"
+  }
+  
+  return parsed_id
 }
 
 def checkAndDeleteCloudFront(id) {


### PR DESCRIPTION
### Requirements

When deleting the Cloudfront Distribution, there is a need to check Cloudfront origin access Identity based on the Account Level

### Description of the Change

* Cross-checked with Cloudfront origin Access before deleting the Cloudfront Distributions.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
