### PR TITLE
Hotfix/Remove Hardcoded Account Info

### DIFF
--- a/core/jazz_es-kinesis-log-streamer/test/test.js
+++ b/core/jazz_es-kinesis-log-streamer/test/test.js
@@ -284,7 +284,7 @@ describe('jazz_es-kinesis-log-stream', function () {
       it('should successfully transform the lambda logs', () => {
         let payload = {
           "messageType": "DATA_MESSAGE",
-          "owner": "102707241671",
+          "owner": "5678",
           "logGroup": "/aws/lambda/newsplunk-jazztest-test-api-dev",
           "logStream": "2018/09/27/[$LATEST]6c3e9188ce7f4fbcb54270ce70fed6c7",
           "subscriptionFilters": [

--- a/core/jazz_metrics/test/test.js
+++ b/core/jazz_metrics/test/test.js
@@ -295,7 +295,7 @@ describe('jazz_metrics', function () {
         "timestamp": "2018-04-11T16:27:34:800",
         "status": "active",
         "provider": "aws",
-        "provider_id": "arn:aws:lambda:test-region:302890901340:function:jazztest_test-service",
+        "provider_id": "arn:aws:lambda:test-region:1234:function:jazztest_test-service",
         "id": "886d901d-fffe-9ac9-becb-a7cfe96fd5dc",
         "domain": "jazztest",
         "asset_type": "lambda"
@@ -1171,7 +1171,7 @@ describe('jazz_metrics', function () {
         "timestamp": "2018-04-11T16:27:34:800",
         "status": "active",
         "provider": "aws",
-        "provider_id": "arn:aws:lambda:test-region:302890901340:function:jazztest_test-service",
+        "provider_id": "arn:aws:lambda:test-region:1234:function:jazztest_test-service",
         "id": "886d901d-fffe-9ac9-becb-a7cfe96fd5dc",
         "domain": "jazztest",
         "asset_type": "lambda"
@@ -1183,7 +1183,7 @@ describe('jazz_metrics', function () {
         "timestamp": "2018-04-11T16:30:46:715",
         "status": "active",
         "provider": "aws",
-        "provider_id": "arn:aws:execute-api:test-region:302890901340:qwertyuiop/test/GET/jazztest/test-service",
+        "provider_id": "arn:aws:execute-api:test-region:1234:qwertyuiop/test/GET/jazztest/test-service",
         "id": "f6aabe91-cc2a-6a79-0e29-68e9ce037426",
         "domain": "jazztest",
         "asset_type": "apigateway"

--- a/core/jazz_splunk-kinesis-log-streamer/test/test.js
+++ b/core/jazz_splunk-kinesis-log-streamer/test/test.js
@@ -380,7 +380,7 @@ describe('jazz_splunk-cw-log-streamer', function () {
     beforeEach(function () {
       lambdaLogsPaylod = {
         "messageType": "DATA_MESSAGE",
-        "owner": "302890901340",
+        "owner": "1234",
         "logGroup": "/aws/lambda/jazztest_test-splunk-prod",
         "logStream": "2018/09/04/[$LATEST]89e64d592ffa4374a9a85dc57a622e14",
         "subscriptionFilters": [
@@ -394,7 +394,7 @@ describe('jazz_splunk-cw-log-streamer', function () {
           {
             "id": "34255429465848969731169788136032554706765058698490413057",
             "timestamp": 1536066582569,
-            "message": "2018-09-04T13:09:42.552Z\tc95e7ca7-b043-11e8-8bbd-75b43bc0efcd\tINFO  \t  { callbackWaitsForEmptyEventLoop: [Getter/Setter],\n  done: [Function: done],\n  succeed: [Function: succeed],\n  fail: [Function: fail],\n  logGroupName: '/aws/lambda/jazztest_test-splunk-prod',\n  logStreamName: '2018/09/04/[$LATEST]89e64d592ffa4374a9a85dc57a622e14',\n  functionName: 'jazztest_test-splunk-prod',\n  memoryLimitInMB: '256',\n  functionVersion: '$LATEST',\n  getRemainingTimeInMillis: [Function: getRemainingTimeInMillis],\n  invokeid: 'c95e7ca7-b043-11e8-8bbd-75b43bc0efcd',\n  awsRequestId: 'c95e7ca7-b043-11e8-8bbd-75b43bc0efcd',\n  invokedFunctionArn: 'arn:aws:lambda:us-west-2:302890901340:function:jazztest_test-splunk-prod' }\n"
+            "message": "2018-09-04T13:09:42.552Z\tc95e7ca7-b043-11e8-8bbd-75b43bc0efcd\tINFO  \t  { callbackWaitsForEmptyEventLoop: [Getter/Setter],\n  done: [Function: done],\n  succeed: [Function: succeed],\n  fail: [Function: fail],\n  logGroupName: '/aws/lambda/jazztest_test-splunk-prod',\n  logStreamName: '2018/09/04/[$LATEST]89e64d592ffa4374a9a85dc57a622e14',\n  functionName: 'jazztest_test-splunk-prod',\n  memoryLimitInMB: '256',\n  functionVersion: '$LATEST',\n  getRemainingTimeInMillis: [Function: getRemainingTimeInMillis],\n  invokeid: 'c95e7ca7-b043-11e8-8bbd-75b43bc0efcd',\n  awsRequestId: 'c95e7ca7-b043-11e8-8bbd-75b43bc0efcd',\n  invokedFunctionArn: 'arn:aws:lambda:us-west-2:1234:function:jazztest_test-splunk-prod' }\n"
           },
           {
             "id": "34255429465871270476368318759174090425037707059996393474",
@@ -419,7 +419,7 @@ describe('jazz_splunk-cw-log-streamer', function () {
           {
             "id": "34255429528335657777452594178615637306725767638247538694",
             "timestamp": 1536066585371,
-            "message": "2018-09-04T13:09:45.370Z\tcb344d6a-b043-11e8-933c-9d414b034894\tINFO  \t  { callbackWaitsForEmptyEventLoop: [Getter/Setter],\n  done: [Function: done],\n  succeed: [Function: succeed],\n  fail: [Function: fail],\n  logGroupName: '/aws/lambda/jazztest_test-splunk-prod',\n  logStreamName: '2018/09/04/[$LATEST]89e64d592ffa4374a9a85dc57a622e14',\n  functionName: 'jazztest_test-splunk-prod',\n  memoryLimitInMB: '256',\n  functionVersion: '$LATEST',\n  getRemainingTimeInMillis: [Function: getRemainingTimeInMillis],\n  invokeid: 'cb344d6a-b043-11e8-933c-9d414b034894',\n  awsRequestId: 'cb344d6a-b043-11e8-933c-9d414b034894',\n  invokedFunctionArn: 'arn:aws:lambda:us-west-2:302890901340:function:jazztest_test-splunk-prod' }\n"
+            "message": "2018-09-04T13:09:45.370Z\tcb344d6a-b043-11e8-933c-9d414b034894\tINFO  \t  { callbackWaitsForEmptyEventLoop: [Getter/Setter],\n  done: [Function: done],\n  succeed: [Function: succeed],\n  fail: [Function: fail],\n  logGroupName: '/aws/lambda/jazztest_test-splunk-prod',\n  logStreamName: '2018/09/04/[$LATEST]89e64d592ffa4374a9a85dc57a622e14',\n  functionName: 'jazztest_test-splunk-prod',\n  memoryLimitInMB: '256',\n  functionVersion: '$LATEST',\n  getRemainingTimeInMillis: [Function: getRemainingTimeInMillis],\n  invokeid: 'cb344d6a-b043-11e8-933c-9d414b034894',\n  awsRequestId: 'cb344d6a-b043-11e8-933c-9d414b034894',\n  invokedFunctionArn: 'arn:aws:lambda:us-west-2:1234:function:jazztest_test-splunk-prod' }\n"
           },
           {
             "id": "34255429528335657777452594178615637306725767638247538695",
@@ -436,7 +436,7 @@ describe('jazz_splunk-cw-log-streamer', function () {
 
       apiGatewayLogsPayload = {
         "messageType": "DATA_MESSAGE",
-        "owner": "302890901340",
+        "owner": "1234",
         "logGroup": "API-Gateway-Execution-Logs_dww0le4qre/prod",
         "logStream": "2a38a4a9316c49e5a833517c45d31070",
         "subscriptionFilters": [

--- a/core/jazz_ui/src/app/secondary-components/create-service/internal/create-service.component.html
+++ b/core/jazz_ui/src/app/secondary-components/create-service/internal/create-service.component.html
@@ -527,7 +527,7 @@
                                 <div class="col-lg-9">
                                     <div class="text">Table ARN</div>
                                     <div class="label-input slct-bx-selected input-wrapper">
-                                        <input type="text" disabled="disabled" class="inline-input input-label aws-events-left-block" value="arn:aws:dynamodb:us-west-2:302890901340:table/">
+                                        <input type="text" disabled="disabled" class="inline-input input-label aws-events-left-block" value="">
                                         <input id="dynamoTable" name="dynamoTable" type="text" [(ngModel)]="eventExpression.dynamoTable"  [focus]="focusDynamo" class="inline-input aws-events-right-block ng-touched ng-not-empty ng-dirty ng-valid-parse ng-valid ng-valid-required" placeholder="Table Name" required>
                                   </div>
                                 </div>
@@ -544,7 +544,7 @@
                                 <div class="col-lg-9">
                                     <div class="text">Stream ARN</div>
                                     <div class="label-input slct-bx-selected input-wrapper">
-                                        <input type="text" disabled="disabled" class="inline-input input-label stream aws-events-left-block" value="arn:aws:kinesis:us-west-2:302890901340:stream/">
+                                        <input type="text" disabled="disabled" class="inline-input input-label stream aws-events-left-block" value="">
                                         <input id="streamARN" name="streamARN" type="text" [(ngModel)]="eventExpression.streamARN" [focus]="focusKinesis" class="inline-input stream aws-events-right-block ng-touched ng-not-empty ng-dirty ng-valid-parse ng-valid ng-valid-required" placeholder="Stream Name" required>
                                   </div>
                                 </div>

--- a/core/jazz_ui/src/app/secondary-components/create-service/internal/create-service.component.ts
+++ b/core/jazz_ui/src/app/secondary-components/create-service/internal/create-service.component.ts
@@ -455,10 +455,8 @@ export class CreateServiceComponent implements OnInit {
         var event = {};
         event["type"] = this.eventExpression.type;
         if (this.eventExpression.type === "dynamodb") {
-          event["source"] = "arn:aws:dynamodb:us-west-2:302890901340:table/" + this.eventExpression.dynamoTable;
           event["action"] = "PutItem";
         } else if (this.eventExpression.type === "kinesis") {
-          event["source"] = "arn:aws:kinesis:us-west-2:302890901340:stream/" + this.eventExpression.streamARN;
           event["action"] = "PutRecord";
         } else if (this.eventExpression.type === "s3") {
           event["source"] = this.eventExpression.S3BucketName;

--- a/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.html
+++ b/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.html
@@ -234,7 +234,7 @@
                               </div>
                               <div class="accReg-dropdown">
                                 <dropdown *ngIf="deploymentTargetSelected !== 'gcp_apigee'" class='dropdown'  [dropdwnContent]="accountList" title="accountDetails" [selected]="accountDetails" (onSelected)="onaccountSelected($event)"></dropdown>
-                                <div *ngIf="deploymentTargetSelected === 'gcp_apigee'" class="defaultDropdown">302890901340 (tmodevops)</div>
+                                <div *ngIf="deploymentTargetSelected === 'gcp_apigee'" class="defaultDropdown">{{primaryAccount}}</div>
                               </div>
                             </div>
                             <div class="">
@@ -243,7 +243,7 @@
                               </div>
                               <div class="accReg-dropdown">
                                 <dropdown *ngIf="deploymentTargetSelected !== 'gcp_apigee'" class='dropdown'  [dropdwnContent]="regionList" title="regionSelected" [selected]="regionSelected" (onSelected)="onregionSelected($event)"></dropdown>
-                                <div *ngIf="deploymentTargetSelected === 'gcp_apigee'" class="defaultDropdown">us-west-2</div>
+                                <div *ngIf="deploymentTargetSelected === 'gcp_apigee'" class="defaultDropdown">{{primaryRegion}}</div>
                               </div>
                             </div>
 

--- a/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.ts
+++ b/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.ts
@@ -95,6 +95,8 @@ export class CreateServiceComponent implements OnInit {
   invalidEventName:boolean = false;
   runtimeKeys : any;
   runtimeObject : any;
+  primaryAccount : string;
+  primaryRegion : string;
   accountList = [];
   regionList = [];
   accountSelected;
@@ -138,6 +140,8 @@ export class CreateServiceComponent implements OnInit {
     this.accountMap.map((item)=>{
       this.accountList.push(item.account + ' (' + item.accountName + ')' )
       if(item.primary){
+        this.primaryAccount = item.account + ' (' + item.accountName + ')' 
+        this.primaryRegion = this.buildEnvironment.aws.region
         this.accountSelected = item.account
         this.accountDetails = item.account + ' (' + item.accountName + ')' 
       }
@@ -176,8 +180,8 @@ export class CreateServiceComponent implements OnInit {
   getSelectedData(data){
     this.deploymentTargetSelected = data;
     if(this.deploymentTargetSelected === 'gcp_apigee'){
-      this.accountSelected = this.buildEnvironment.defaults.account_id,
-      this.regionSelected = this.buildEnvironment.defaults.region
+      this.accountSelected = this.buildEnvironment.aws.account_number,
+      this.regionSelected = this.buildEnvironment.aws.region
     }
   }
 


### PR DESCRIPTION
### Requirements

* Remove the hardcoded account id from throughout the jazz repo

### Description of the Change

Removed the hardcoded account id from the test files and from the UI files as well. Also removed some portion of code related to account info from create-service internal folders. Since these files are not in use, removing some lines of code won't effect anything. Otherwise doing the similar changes like OSS folders doesn't make any sense as these internal files are not in use. Also tested locally and working fine.

### Benefits

No hardcoded account info are visible in the repo

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
