### PR TITLE
 Adding sample log statements in templates

### DIFF
--- a/core/jazz_splunk-kinesis-log-streamer/index.js
+++ b/core/jazz_splunk-kinesis-log-streamer/index.js
@@ -56,7 +56,8 @@ function handler(event, context, callback) {
 
     try {
 
-      event.Records.forEach(eachRecord => {
+      for (let i = 0; i < event.Records.length; i++) {
+        let eachRecord = event.Records[i];
         // CloudWatch Logs data is base64 encoded so decode here
         let payload = new Buffer(eachRecord.kinesis.data, 'base64');
         logger.debug("payload:" + JSON.stringify(payload));
@@ -96,7 +97,7 @@ function handler(event, context, callback) {
               });
           }
         });
-      });
+      }
 
     } catch (e) {
       logger.error("Error:" + JSON.stringify(e));

--- a/templates/api-template-go/main.go
+++ b/templates/api-template-go/main.go
@@ -46,7 +46,7 @@ func Handler(ctx context.Context, event map[string]interface{}) (Response, error
 	// Initialize Config Components
 	configModule := new(Config)
 	configModule.LoadConfiguration(ctx , event )
-	// Get Config values 
+	// Get Config values
 	configValue := viper.Get("configKey").(string) // returns string
 
 	sampleResponse :=map[string]string {
@@ -62,10 +62,12 @@ func Handler(ctx context.Context, event map[string]interface{}) (Response, error
 		var payLoad map[string]interface{}
 		// Your GET method should be handled here
 		if (event["method"].(string) == "GET"){
+      logger.VERBOSE("Sample log inside GET");
 			payLoad = event["query"].(map[string]interface{})
 		}
 		//Your POST method should be handled here
 		if (event["method"].(string) == "POST"){
+      logger.VERBOSE("Sample log inside POST");
 			payLoad = event["body"].(map[string]interface{})
 		}
 		return Response{
@@ -80,5 +82,5 @@ func Handler(ctx context.Context, event map[string]interface{}) (Response, error
 func main() {
 	//Start function to trigger Lambda
 	lambda.Start(Handler)
-	
+
 }

--- a/templates/api-template-go/main.go
+++ b/templates/api-template-go/main.go
@@ -62,12 +62,12 @@ func Handler(ctx context.Context, event map[string]interface{}) (Response, error
 		var payLoad map[string]interface{}
 		// Your GET method should be handled here
 		if (event["method"].(string) == "GET"){
-      logger.VERBOSE("Sample log inside GET");
+      logger.INFO("Sample log inside GET");
 			payLoad = event["query"].(map[string]interface{})
 		}
 		//Your POST method should be handled here
 		if (event["method"].(string) == "POST"){
-      logger.VERBOSE("Sample log inside POST");
+      logger.INFO("Sample log inside POST");
 			payLoad = event["body"].(map[string]interface{})
 		}
 		return Response{

--- a/templates/api-template-java/src/main/java/com/slf/services/Handler.java
+++ b/templates/api-template-java/src/main/java/com/slf/services/Handler.java
@@ -14,7 +14,7 @@ import com.slf.exceptions.BadRequestException;
 	This is a java template for developing and deploying functions. The template is based on the
 	predefined interfaces provided by the AWS Lambda Java core library to create your function handler.
 
-	@Author: 
+	@Author:
 	@version: 1.0
 	@Date:
 
@@ -29,7 +29,7 @@ public class Handler extends BaseJazzRequestHandler {
      * processing logic to serve the request from User
   	*/
 	public Response execute(Map<String, Object> input, Context context) {
-        
+
         /* Read environment specific configurations from properties file */
         String configStr = configObject.getConfig("config_key");
         LOGGER.info("You are using the env key: " + configStr);
@@ -48,6 +48,7 @@ public class Handler extends BaseJazzRequestHandler {
         Map<String, String> data = new HashMap();
 
         if ("GET".equalsIgnoreCase(this.method)) {
+            LOGGER.info("Sample log inside GET");
             data.put("message", "GET executed successfully");
             return new Response(data, this.query);
         } else if ("POST".equalsIgnoreCase(this.method)) {

--- a/templates/api-template-nodejs/index.js
+++ b/templates/api-template-nodejs/index.js
@@ -38,12 +38,13 @@ module.exports.handler = (event, context, cb) => {
 
     //Your GET method should be handled here
     if (event && event.method && event.method === 'GET') {
-      logger.verbose(sampleResponse);
+      logger.verbose("sample response in GET" + sampleResponse);
       cb(null, responseObj(sampleResponse, event.query));
     }
 
     //Your POST method should be handled here
     if (event && event.method && event.method === 'POST') {
+      logger.verbose("sample response in POST" + sampleResponse);
       cb(null, responseObj(sampleResponse, event.body));
     }
 

--- a/templates/api-template-nodejs/index.js
+++ b/templates/api-template-nodejs/index.js
@@ -38,13 +38,13 @@ module.exports.handler = (event, context, cb) => {
 
     //Your GET method should be handled here
     if (event && event.method && event.method === 'GET') {
-      logger.verbose("sample response in GET" + sampleResponse);
+      logger.info("sample response in GET" + sampleResponse);
       cb(null, responseObj(sampleResponse, event.query));
     }
 
     //Your POST method should be handled here
     if (event && event.method && event.method === 'POST') {
-      logger.verbose("sample response in POST" + sampleResponse);
+      logger.info("sample response in POST" + sampleResponse);
       cb(null, responseObj(sampleResponse, event.body));
     }
 

--- a/templates/api-template-python/index.py
+++ b/templates/api-template-python/index.py
@@ -23,7 +23,7 @@ def handler(event, context):
         ## ==== Sample code to fetch environment specific configurations ====
         # myconfig = config.get_config('default')
         # logger.info ('One of the environment configuration: config_key => ' + myconfig['config_key'])
-        
+
         ## ==== Log message samples ====
         # logger.error('Runtime errors or unexpected conditions.')
         # logger.warn('Runtime situations that are undesirable, but not wrong')
@@ -40,9 +40,11 @@ def handler(event, context):
         if 'method' in event:
             if event['method'] == "POST":
                 # Handle Post response here
+                logger.verbose('Sample log inside POST')
                 response = CustomResponse(data, event['body']).get_json()
             else:
                 # Handle Get/other response here.
+                logger.verbose('Sample log inside GET')
                 response = CustomResponse(data, event['query']).get_json()
         return response
     except Exception as e:

--- a/templates/api-template-python/index.py
+++ b/templates/api-template-python/index.py
@@ -40,11 +40,11 @@ def handler(event, context):
         if 'method' in event:
             if event['method'] == "POST":
                 # Handle Post response here
-                logger.verbose('Sample log inside POST')
+                logger.info('Sample log inside POST')
                 response = CustomResponse(data, event['body']).get_json()
             else:
                 # Handle Get/other response here.
-                logger.verbose('Sample log inside GET')
+                logger.info('Sample log inside GET')
                 response = CustomResponse(data, event['query']).get_json()
         return response
     except Exception as e:

--- a/templates/lambda-template-nodejs/index.js
+++ b/templates/lambda-template-nodejs/index.js
@@ -36,7 +36,7 @@ module.exports.handler = (event, context, cb) => {
       "configKeys": myVal
     };
 
-    logger.debug("Sample log for nodejs service");
+    logger.info("Sample log for nodejs service");
     return cb(null, responseObj(sampleResponse, event));
 
   } catch (e) {

--- a/templates/lambda-template-nodejs/index.js
+++ b/templates/lambda-template-nodejs/index.js
@@ -36,6 +36,7 @@ module.exports.handler = (event, context, cb) => {
       "configKeys": myVal
     };
 
+    logger.debug("Sample log for nodejs service");
     return cb(null, responseObj(sampleResponse, event));
 
   } catch (e) {

--- a/templates/lambda-template-python/index.py
+++ b/templates/lambda-template-python/index.py
@@ -28,6 +28,8 @@ def handler(event, context):
     # logger.verbose('Generally speaking, most log lines should be verbose.')
     # logger.debug('Detailed information on the flow through the system.')
 
+    logger.debug('Sample log for your python service.')
+
     return {
         "message": "Your function executed successfully!",
         "event": event

--- a/templates/lambda-template-python/index.py
+++ b/templates/lambda-template-python/index.py
@@ -28,7 +28,7 @@ def handler(event, context):
     # logger.verbose('Generally speaking, most log lines should be verbose.')
     # logger.debug('Detailed information on the flow through the system.')
 
-    logger.debug('Sample log for your python service.')
+    logger.info('Sample log for your python service.')
 
     return {
         "message": "Your function executed successfully!",

--- a/templates/sls-app-template-go/functions/function1/main.go
+++ b/templates/sls-app-template-go/functions/function1/main.go
@@ -36,7 +36,8 @@ func Handler(ctx context.Context, event map[string]interface{}) (Response, error
 	 logger.VERBOSE("Generally speaking, most lines logged by your application should be written as verbose.");
 	 logger.DEBUG("Detailed information on the flow through the system.");
 	*/
-	logger.INFO("Sample log for function1")
+  logger.INFO("Interesting runtime events (Eg. connection established, data fetched etc.)")
+  logger.INFO("Sample log for function1")
 	// Initialize Config Components
 	configModule := new(components.Config)
 	configModule.LoadConfiguration(ctx, event)

--- a/templates/sls-app-template-go/functions/function1/main.go
+++ b/templates/sls-app-template-go/functions/function1/main.go
@@ -36,7 +36,7 @@ func Handler(ctx context.Context, event map[string]interface{}) (Response, error
 	 logger.VERBOSE("Generally speaking, most lines logged by your application should be written as verbose.");
 	 logger.DEBUG("Detailed information on the flow through the system.");
 	*/
-	logger.INFO("Interesting runtime events (Eg. connection established, data fetched etc.)")
+	logger.INFO("Sample log for function1")
 	// Initialize Config Components
 	configModule := new(components.Config)
 	configModule.LoadConfiguration(ctx, event)

--- a/templates/sls-app-template-go/functions/function2/main.go
+++ b/templates/sls-app-template-go/functions/function2/main.go
@@ -36,7 +36,8 @@ func Handler(ctx context.Context, event map[string]interface{}) (Response, error
 	 logger.VERBOSE("Generally speaking, most lines logged by your application should be written as verbose.");
 	 logger.DEBUG("Detailed information on the flow through the system.");
 	*/
-	logger.INFO("Sample log for function2")
+  logger.INFO("Interesting runtime events (Eg. connection established, data fetched etc.)")
+  logger.INFO("Sample log for function2")
 	// Initialize Config Components
 	configModule := new(components.Config)
 	configModule.LoadConfiguration(ctx, event)

--- a/templates/sls-app-template-go/functions/function2/main.go
+++ b/templates/sls-app-template-go/functions/function2/main.go
@@ -36,7 +36,7 @@ func Handler(ctx context.Context, event map[string]interface{}) (Response, error
 	 logger.VERBOSE("Generally speaking, most lines logged by your application should be written as verbose.");
 	 logger.DEBUG("Detailed information on the flow through the system.");
 	*/
-	logger.INFO("Interesting runtime events (Eg. connection established, data fetched etc.)")
+	logger.INFO("Sample log for function2")
 	// Initialize Config Components
 	configModule := new(components.Config)
 	configModule.LoadConfiguration(ctx, event)

--- a/templates/sls-app-template-java/src/main/java/com/slf/services/functions/function1/Function1.java
+++ b/templates/sls-app-template-java/src/main/java/com/slf/services/functions/function1/Function1.java
@@ -51,7 +51,9 @@ public class Function1 extends BaseRequestHandler {
     logger.error("Runtime errors or unexpected conditions.");
     logger.fatal("Very severe error events that will presumably lead the application to abort");
 
-        /* Sample output data */
+    logger.info("Sample log for function1");
+
+    /* Sample output data */
 		HashMap<String, String> data = new HashMap<String, String>();
 		String val = (String) body.get("key");
 		data.put("name", val);

--- a/templates/sls-app-template-java/src/main/java/com/slf/services/functions/function2/Function2.java
+++ b/templates/sls-app-template-java/src/main/java/com/slf/services/functions/function2/Function2.java
@@ -32,6 +32,7 @@ public class Function2 extends BaseRequestHandler {
 			throw new BadRequestException("Invalid or empty input payload");
 		}
 
+    logger.info("Sample log for function2");
         /* Sample output data */
 		HashMap<String, String> data = new HashMap<String, String>();
 		String val = (String) body.get("key");

--- a/templates/sls-app-template-nodejs/functions/function1/index.js
+++ b/templates/sls-app-template-nodejs/functions/function1/index.js
@@ -42,7 +42,6 @@ module.exports.handler = (event, context, cb) => {
 
   } catch (e) {
     //Sample Error response for internal server error
-		console.log('----e------>', e);
     return cb(JSON.stringify(errorHandler.throwInternalServerError("Sample error message")));
 
     //Sample Error response for Not Found Error

--- a/templates/sls-app-template-nodejs/functions/function1/index.js
+++ b/templates/sls-app-template-nodejs/functions/function1/index.js
@@ -30,6 +30,8 @@ module.exports.handler = (event, context, cb) => {
     logger.debug('Detailed information on the flow through the system.');
     */
 
+   logger.info("Sample log for function1");
+
     const sampleResponse = {
       "foo": "foo-value",
       "bar": "bar-value",

--- a/templates/sls-app-template-nodejs/functions/function2/index.js
+++ b/templates/sls-app-template-nodejs/functions/function2/index.js
@@ -30,6 +30,7 @@ module.exports.handler = (event, context, cb) => {
     logger.debug('Detailed information on the flow through the system.');
     */
 
+   logger.info("Sample log for function2");
     const sampleResponse = {
       "foo": "foo-value2",
       "bar": "bar-value2",

--- a/templates/sls-app-template-python/functions/function1/index.py
+++ b/templates/sls-app-template-python/functions/function1/index.py
@@ -30,6 +30,7 @@ def handler(event, context):
     # logger.verbose('Generally speaking, most log lines should be verbose.')
     # logger.debug('Detailed information on the flow through the system.')
 
+    logger.debug('Sample response for function1.')
     return {
         "message": "Your function executed successfully!",
         "event": event

--- a/templates/sls-app-template-python/functions/function1/index.py
+++ b/templates/sls-app-template-python/functions/function1/index.py
@@ -30,7 +30,7 @@ def handler(event, context):
     # logger.verbose('Generally speaking, most log lines should be verbose.')
     # logger.debug('Detailed information on the flow through the system.')
 
-    logger.debug('Sample response for function1.')
+    logger.info('Sample response for function1.')
     return {
         "message": "Your function executed successfully!",
         "event": event

--- a/templates/sls-app-template-python/functions/function2/index.py
+++ b/templates/sls-app-template-python/functions/function2/index.py
@@ -30,7 +30,7 @@ def handler(event, context):
     # logger.verbose('Generally speaking, most log lines should be verbose.')
     # logger.debug('Detailed information on the flow through the system.')
 
-    logger.debug('Sample response for function2.')
+    logger.info('Sample response for function2.')
     return {
         "message": "Your function executed successfully!",
         "event": event

--- a/templates/sls-app-template-python/functions/function2/index.py
+++ b/templates/sls-app-template-python/functions/function2/index.py
@@ -30,6 +30,7 @@ def handler(event, context):
     # logger.verbose('Generally speaking, most log lines should be verbose.')
     # logger.debug('Detailed information on the flow through the system.')
 
+    logger.debug('Sample response for function2.')
     return {
         "message": "Your function executed successfully!",
         "event": event


### PR DESCRIPTION
### Requirements

 Adding sample log statements in templates

### Description of the Change

- Added sample log statement in all the service templates
- Changed forEach to for loop in logstreamers

### Benefits

No need to uncomment the log statement for checking logs

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
