### PR TITLE
Fixing deletion issue of services with broken DD

### DIFF
--- a/builds/delete-serverless-service-build-pack/Jenkinsfile
+++ b/builds/delete-serverless-service-build-pack/Jenkinsfile
@@ -258,7 +258,7 @@ node {
 				stage('Undeploy Service') {
 					for (_envId in environmentIds) {
 						current_environment_id = _envId
-						loadServerlessYml(service_config, _envId)
+            def has_serverless_yml = 	loadServerlessYml(service_config, _envId)
 						try {
 							def branch = environmentMetadataLoader.getEnvironmentBranchName(_envId)
 							if (branch && branch != 'NA') {
@@ -271,7 +271,8 @@ node {
 							echo 'undeploying function for environment: ' + _envId
 
 							cleanupEventSourceMapping(_envId)
-							unDeployService(_envId)
+              if (has_serverless_yml) unDeployService(_envId)
+              else unDeployCloudformationStack(_envId)
 
 							if (configLoader.CODE_QUALITY.SONAR.ENABLE_SONAR == "true" && configLoader.CODE_QUALITY.SONAR.CLEANUP == "true") {
 								cleanupCodeQualityReports()
@@ -449,7 +450,12 @@ def unDeployService(stage) {
 			}
 			def envBucketKey = "${env_key}${configLoader.JAZZ.PLATFORM.AWS.S3.BUCKET_NAME_SUFFIX}"
 			def bucketObject = utilModule.getAccountBucketName(service_config);
-			sh "serverless remove --stage ${stage} --verbose  --bucket ${bucketObject[env_key]} --profile ${credsId}"
+			try {
+          sh "serverless remove --stage ${stage} --verbose  --bucket ${bucketObject[env_key]} --profile ${credsId}"
+      } catch (ex) {
+        echo "Serverless stack removal failed. "
+        unDeployCloudformationStack(stage)
+      }
 
 			echo "Service undeployed"
 		} catch (ex) {
@@ -458,6 +464,21 @@ def unDeployService(stage) {
 			resetCredentials(credsId)
 		}
 	}
+}
+
+def unDeployCloudformationStack(env) {
+  echo "Manualy removing the stack by using aws cli."
+  withCredentials([
+		[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: service_config.credentialId]
+	]) {
+    def cfStackName = "${instance_prefix}-${service_config['domain']}-${service_config['service']}-${env}"
+    try {
+      def res = sh(script: "aws cloudformation delete-stack --stack-name ${cfStackName} --region ${service_config['region']} ", returnStdout: true)
+      echo "Delete stack resp: ${res}"
+    } catch (ex) {
+      echo "Error occured while deleting cloudformation stack ${cfStackName} : ${ex}"
+    }
+  }
 }
 
 /**
@@ -1097,9 +1118,15 @@ def loadServerlessYml(config, env){
 	environmentMetadataLoader.setEnvironmentLogicalId(env) //set Current Environment
 	//Get deployment descriptor from environments
   env_deployment_descriptor = environmentMetadataLoader.getEnvDeploymentDescriptor()
-	def deploymentDescriptor = slsBuildRules.prepareServerlessYml(config, env, configLoader, env_deployment_descriptor) // Generating the deployment descriptor
-	echo "prepareServerlessYml = ${deploymentDescriptor}"
-	writeYaml(file: './serverless.yml', data: deploymentDescriptor)
+  try {
+    def deploymentDescriptor = slsBuildRules.prepareServerlessYml(config, env, configLoader, env_deployment_descriptor) // Generating the deployment descriptor
+	  echo "prepareServerlessYml = ${deploymentDescriptor}"
+	  writeYaml(file: './serverless.yml', data: deploymentDescriptor)
+    return true
+  } catch (ex) {
+    echo "Failed to load the serverless.yml for ${env} environment."
+    return false
+  }
 }
 
 def loadServerlessConfig() {

--- a/builds/delete-serverless-service-build-pack/Jenkinsfile
+++ b/builds/delete-serverless-service-build-pack/Jenkinsfile
@@ -450,12 +450,8 @@ def unDeployService(stage) {
 			}
 			def envBucketKey = "${env_key}${configLoader.JAZZ.PLATFORM.AWS.S3.BUCKET_NAME_SUFFIX}"
 			def bucketObject = utilModule.getAccountBucketName(service_config);
-			try {
-          sh "serverless remove --stage ${stage} --verbose  --bucket ${bucketObject[env_key]} --profile ${credsId}"
-      } catch (ex) {
-        echo "Serverless stack removal failed. "
-        unDeployCloudformationStack(stage)
-      }
+
+      sh "serverless remove --stage ${stage} --verbose  --bucket ${bucketObject[env_key]} --profile ${credsId}"
 
 			echo "Service undeployed"
 		} catch (ex) {

--- a/builds/jazz-build-module/sls-app/sbr.groovy
+++ b/builds/jazz-build-module/sls-app/sbr.groovy
@@ -1122,8 +1122,8 @@ def prepareServerlessYml(aConfig, env, configLoader, envDeploymenDescriptor) {
   try {
     def appContent = readFile('application.yml').trim()
     if(!appContent.isEmpty()) deploymentDescriptor = appContent
-    } catch(e) {
-      echo "Error occured while reading application.yml. The default value from config will be used. Exception is $e"
+    } catch(e) { // TODO to catch the type error
+      echo "The application.yml does not exist in the code. So the default value from config will be used.$e"
     }
 
     def doc = deploymentDescriptor  ? readYaml(text: deploymentDescriptor ) : [:] // If no descriptor present then simply making an empty one. The readYaml default behavior is to return empty string back that is harful as Map not String is expected below

--- a/builds/jazz-build-module/sls-app/serverless-build-rules.yml
+++ b/builds/jazz-build-module/sls-app/serverless-build-rules.yml
@@ -567,7 +567,7 @@ function:
 
     runtime:
       sbr-type: enum
-      sbr-render: user-wins
+      sbr-render: config-wins
       sbr-constraint:
         sbr-enum:
           - nodejs8.10

--- a/core/jazz_assets/config/global-config.json
+++ b/core/jazz_assets/config/global-config.json
@@ -35,8 +35,7 @@
     "iam_role",
     "sqs",
     "kinesis_stream",
-    "apigee_proxy",
-    "http"
+    "apigee_proxy"
   ],
   "ASSET_STATUS": [
     "active",


### PR DESCRIPTION
### Requirements

The services with the broken deployment descriptor were failing

### Description of the Change

- The cloudformation stack deleted by using aws cli command if the serverless.yml preparation broken
- The cloudformation stack deleted by using aws cli command if the serverless stack removal fails

### Benefits

The service getting cleaned successfully.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
