### PR TITLE
Cleanup jenkins workspace

### DIFF
--- a/builds/delete-serverless-service-build-pack/Jenkinsfile
+++ b/builds/delete-serverless-service-build-pack/Jenkinsfile
@@ -41,6 +41,7 @@ import groovy.json.JsonSlurperClassic
 @Field def accountInfo;
 
 node {
+  try {
 	echo "Starting delete service job with params : $params"
 
 	jazzBuildModuleURL = getBuildModuleUrl()
@@ -328,6 +329,11 @@ node {
 			events.sendCompletedEvent('DELETE_PROJECT', 'deletion completed', context_map)
 		}
 	}
+  } catch (err) {
+   throw err
+  } finally {
+   deleteDir()
+  }
 }
 
 def deletePolicies(serviceId, authToken, aclUrl) {

--- a/builds/jenkins-build-pack-api/Jenkinsfile
+++ b/builds/jenkins-build-pack-api/Jenkinsfile
@@ -34,6 +34,7 @@ import groovy.transform.Field
 @Field def current_environment
 
 node() {
+  try {
   def jazzBuildModuleURL = getBuildModuleUrl()
   loadBuildModules(jazzBuildModuleURL)
 
@@ -405,6 +406,11 @@ node() {
     }//stage of deployment to an environment ends here
 
   }//dir ends here
+  } catch (err) {
+   throw err
+  } finally {
+   deleteDir()
+  }
 }
 
 def updateSwagger(){

--- a/builds/jenkins-build-pack-lambda/Jenkinsfile
+++ b/builds/jenkins-build-pack-lambda/Jenkinsfile
@@ -35,7 +35,7 @@ import groovy.transform.Field
 @Field def environment_logical_id
 
 node() {
-
+  try {
   def jazzBuildModuleURL = getBuildModuleUrl()
   loadBuildModules(jazzBuildModuleURL)
 
@@ -361,6 +361,11 @@ node() {
 
       } //end of withCredentials
     } //end of deployment to an environment
+  }
+  } catch (err) {
+   throw err
+  } finally {
+   deleteDir()
   }
 }
 

--- a/builds/jenkins-build-pack-sls-app/Jenkinsfile
+++ b/builds/jenkins-build-pack-sls-app/Jenkinsfile
@@ -36,7 +36,7 @@ import groovy.transform.Field
 @Field def environment_logical_id
 
 node() {
-
+  try {
   sh 'rm -rf *'
   def jazzBuildModuleURL = getBuildModuleUrl()
   loadBuildModules(jazzBuildModuleURL)
@@ -382,6 +382,11 @@ node() {
 
       } //end of withCredentials
     } //end of deployment to an environment
+  }
+  } catch (err) {
+   throw err
+  } finally {
+   deleteDir()
   }
 }
 

--- a/builds/jenkins-build-pack-website/Jenkinsfile
+++ b/builds/jenkins-build-pack-website/Jenkinsfile
@@ -33,6 +33,7 @@ import groovy.transform.Field
 @Field def service_config
 
 node()  {
+  try {
 	def jazzBuildModuleURL = getBuildModuleUrl()
 	loadBuildModules(jazzBuildModuleURL)
 
@@ -292,6 +293,11 @@ node()  {
 			}
 		}
 	}
+	} catch (err) {
+   throw err
+  } finally {
+   deleteDir()
+  }
 }
 
 def generateAssetUrl(){

--- a/builds/jenkins-delete-resources/Jenkinsfile
+++ b/builds/jenkins-delete-resources/Jenkinsfile
@@ -24,6 +24,7 @@ import groovy.json.JsonOutput
 
 
 node {
+ try {
  echo "Starting the Job with Params ${params}"
  inputParams = params.input
  // Load the config
@@ -53,7 +54,7 @@ node {
  if (finalAccounts.size() > 0) {
   //Parse the Accounts and delete IAM,APIGateway,s3Buckets
   for (account in finalAccounts) {
-   credentialId = account['CREDENTIAL_ID'] 
+   credentialId = account['CREDENTIAL_ID']
    def accountID = account['ACCOUNTID'];
    def iamRoles = account["IAM"]
   def cloudFront = account["CLOUDFRONT"]
@@ -61,7 +62,7 @@ node {
     withCredentials([
       [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "${credentialId}"]
     ]) {
-       
+
         // Get all Regions
         def allregions = account["REGIONS"]
         for (awsregion in allregions) {
@@ -90,6 +91,11 @@ node {
   }
  } else {
   echo "No Accounts available for Deletion"
+ }
+ } catch (err) {
+  throw err
+ } finally {
+  deleteDir()
  }
 }
 
@@ -159,7 +165,7 @@ def deleteIam(roleName) {
   }
   // If Iam exists delete it
   if (status) {
-   //check and delete Custom Policies attached 
+   //check and delete Custom Policies attached
    deleteInlinePolicies(roleName)
    //check and delete if policies attached
    detachIamPolicies(roleName)
@@ -319,7 +325,7 @@ def deletes3Bucket(bucketName) {
 
 /**
   Function for Deleting Primary Account Role Policy
-  Accepts credentialId 
+  Accepts credentialId
   Check if policy exists and delete it
 **/
 def deletePrimaryAccountPolicy(accountId, accountsArray){
@@ -335,7 +341,7 @@ def deletePrimaryAccountPolicy(accountId, accountsArray){
             echo "${instance_prefix}_NonPrimaryAssumePolicy not exists"
             status = false
           }
-          
+
           if (status) {
             sh "aws iam delete-role-policy --role-name ${instance_prefix}_platform_services --policy-name ${instance_prefix}_${accountId}_NonPrimaryAssumePolicy"
             sleep(time: 10, unit: "SECONDS")
@@ -386,7 +392,7 @@ def deleteUserServices(regionAws) {
 /**
 * Delete cloudformation Stack
 **/
-def deleteStack(stackName, regionAws) { 
+def deleteStack(stackName, regionAws) {
   try {
     def status = true;
     try {
@@ -439,7 +445,7 @@ def parseOriginAccessIdentity(id){
   } else {
      parsed_id = "origin-access-identity/cloudfront/${id}"
   }
-  
+
   return parsed_id
 }
 
@@ -451,7 +457,7 @@ def checkAndDeleteCloudFront(id) {
         // Disable the CloudFront Distribution
         echo "Distribution is enabled"
         disableCloudFront(id, config)
-      } 
+      }
       deleteCloudFront(id)
     } catch (ex) {
         echo "{ex.message}"
@@ -513,7 +519,7 @@ def getDistributionConfig(id) {
     } catch (ex) {
         echo "${ex.message}"
     }
-    return config  
+    return config
 }
 
 /**

--- a/builds/service-onboarding-build-pack/Jenkinsfile
+++ b/builds/service-onboarding-build-pack/Jenkinsfile
@@ -38,6 +38,7 @@ import groovy.transform.Field
 @Field def context_map = [:]
 
 node  {
+  try {
 	def accountDetailsPrimary
 	jazzBuildModuleURL = getBuildModuleUrl()
 	loadBuildModules(jazzBuildModuleURL)
@@ -338,6 +339,11 @@ node  {
 			}
 		}
 	}
+	} catch (err) {
+   throw err
+  } finally {
+   deleteDir()
+  }
 }
 
 /**
@@ -535,4 +541,3 @@ def readDir() {
   }
   return targetPaths
 }
-

--- a/core/jazz_ui/Jenkinsfile_Platform
+++ b/core/jazz_ui/Jenkinsfile_Platform
@@ -65,6 +65,7 @@ def aws_configure() {
 * Start the Pipeline stages
 */
 node ()  {
+  try {
   stage('Loading Config-Loader') {
     def jazzBuildModuleURL = getBuildModuleUrl()
     loadBuildModules(jazzBuildModuleURL)
@@ -74,7 +75,7 @@ node ()  {
   }
 
   stage('Checking out Jazz_UI repo') {
-    dir('jazz_ui') {    
+    dir('jazz_ui') {
 
       checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[credentialsId: config_loader.REPOSITORY.CREDENTIAL_ID, url: scmModule.getCoreRepoCloneUrl("jazz_ui")]]])
       def jazz_prod_api_id = getApiGatewayCore()
@@ -167,6 +168,11 @@ node ()  {
   }
   stage('Invalidating CloudFront') {
     invalidate_cloudfront(cf_id)
+  }
+  } catch (err) {
+   throw err
+  } finally {
+   deleteDir()
   }
 }
 


### PR DESCRIPTION
### Requirements

* We are using Fargate as the Container Service for our ECS to host gitlab and jenkins in our training environment. Fargate has a 10 GB limit on the disk space which we are going over almost immediately after we setup Jazz. We need to delete the build folders to free up diskspace. See: https://github.com/tmobile/jazz-installer/wiki#limitations

### Description of the Change

Added jenkins workspace cleanup method

### Benefits

Avoid "No Disk Space left" error due to disk size limit in ECS

### Possible Drawbacks

NA

### Applicable Issues

NA
