### PR TITLE
:bug: Setting default ProviderTimeout for api and function

### DIFF
--- a/core/jazz_create-serverless-service/config/dev-config.json
+++ b/core/jazz_create-serverless-service/config/dev-config.json
@@ -8,6 +8,7 @@
   "TOKEN_URL": "/dev/jazz/login",
   "SERVICE_USER": "{jazz_admin}",
   "TOKEN_CREDS": "{jazz_admin_creds}",
+  "DEFAULT_PROVIDER_TIMEOUT": 30,
   "DEPLOYMENT_TARGETS": {
     "api": [
       "{conf_deployment_targets_api}"

--- a/core/jazz_create-serverless-service/config/prod-config.json
+++ b/core/jazz_create-serverless-service/config/prod-config.json
@@ -8,6 +8,7 @@
   "TOKEN_URL": "/prod/jazz/login",
   "SERVICE_USER": "{jazz_admin}",
   "TOKEN_CREDS": "{jazz_admin_creds}",
+  "DEFAULT_PROVIDER_TIMEOUT": 30,
   "DEPLOYMENT_TARGETS": {
     "api": [
       "{conf_deployment_targets_api}"

--- a/core/jazz_create-serverless-service/config/stg-config.json
+++ b/core/jazz_create-serverless-service/config/stg-config.json
@@ -8,6 +8,7 @@
   "TOKEN_URL": "/stg/jazz/login",
   "SERVICE_USER": "{jazz_admin}",
   "TOKEN_CREDS": "{jazz_admin_creds}",
+  "DEFAULT_PROVIDER_TIMEOUT": 30,
   "DEPLOYMENT_TARGETS": {
     "api": [
       "{conf_deployment_targets_api}"

--- a/core/jazz_create-serverless-service/config/test-config.json
+++ b/core/jazz_create-serverless-service/config/test-config.json
@@ -4,6 +4,7 @@
   "API_TOKEN": "{api_token}",
   "SVC_USER": "{ci_user}",
   "SERVICE_API_URL": "https://test.execute-api.test-region.amazonaws.com",
+  "DEFAULT_PROVIDER_TIMEOUT": 30,
   "DEPLOYMENT_TARGETS": {
     "api": [
       "{conf_deployment_targets_api}"

--- a/core/jazz_create-serverless-service/index.js
+++ b/core/jazz_create-serverless-service/index.js
@@ -351,6 +351,12 @@ var getServiceData = (service_creation_data, authToken, configData, deploymentTa
     if (service_creation_data.service_type === "api" || service_creation_data.service_type === "function" || service_creation_data.service_type === "sls-app") {
       serviceMetadataObj.providerRuntime = service_creation_data.runtime;
     }
+    
+    //Adding providerTimeout key in service catalog
+    if (service_creation_data.service_type === "api" || service_creation_data.service_type === "function") {
+        // default to 30 seconds
+        serviceMetadataObj.providerTimeout = configData.DEFAULT_PROVIDER_TIMEOUT;
+    }
 
     inputs.DEPLOYMENT_ACCOUNTS = deploymentAccounts;
 


### PR DESCRIPTION
### Requirements

* Provide default providerTimeout for api and function service types

### Description of the Change

* Sets the default providerTimeout to 30 seconds for API and Function during service creation
