### PR TITLE
Removing support for nodejs8

### DIFF
--- a/builds/jazz-build-module/sls-app/serverless-build-rules.yml
+++ b/builds/jazz-build-module/sls-app/serverless-build-rules.yml
@@ -69,7 +69,6 @@ provider:
     sbr-render: config-wins
     sbr-constraint:
       sbr-enum:
-        - nodejs8.10
         - nodejs10.x
         - java8
         - python3.6
@@ -578,7 +577,6 @@ function:
       sbr-render: config-wins
       sbr-constraint:
         sbr-enum:
-          - nodejs8.10
           - nodejs10.x
           - java8
           - python3.6

--- a/builds/jenkins-build-pack-api/Jenkinsfile
+++ b/builds/jenkins-build-pack-api/Jenkinsfile
@@ -900,7 +900,7 @@ def validateDeploymentConfigurations(def prop) {
       error "Wrong configuration. Value for Key 'providerRuntime' is missing in the configuration"
 
     } else {
-      def validRuntimes = ["nodejs8.10", "nodejs10.x", "python3.6", "java8", "go1.x"]
+      def validRuntimes = ["nodejs10.x", "python3.6", "java8", "go1.x"]
       def flag = false
       for (int i = 0; i < validRuntimes.size(); i++) {
         if (_runtime == validRuntimes[i]) {

--- a/builds/jenkins-build-pack-function/Jenkinsfile
+++ b/builds/jenkins-build-pack-function/Jenkinsfile
@@ -716,7 +716,7 @@ def validateDeploymentConfigurations(def prop) {
 		if (_runtime == "") {
 			error "Wrong configuration. Value for Key 'providerRuntime' is missing in the configuration"
 		} else {
-			def validRuntimes = ["nodejs8.10", "nodejs10.x", "python3.6", "java8", "go1.x", "c#"]
+			def validRuntimes = ["nodejs10.x", "python3.6", "java8", "go1.x", "c#"]
 			def flag = false
 
 			for (int i = 0; i < validRuntimes.size(); i++) {

--- a/builds/jenkins-build-pack-sls-app/Jenkinsfile
+++ b/builds/jenkins-build-pack-sls-app/Jenkinsfile
@@ -654,7 +654,7 @@ def validateDeploymentConfigurations(def prop) {
 		if (_runtime == "") {
 			error "Wrong configuration. Value for Key 'providerRuntime' is missing in the configuration"
 		} else {
-			def validRuntimes = ["nodejs8.10", "nodejs10.x", "python3.6", "java8", "go1.x"]
+			def validRuntimes = ["nodejs10.x", "python3.6", "java8", "go1.x"]
 			def flag = false
 
 			for (int i = 0; i < validRuntimes.size(); i++) {

--- a/core/jazz_create-serverless-service/swagger/swagger.json
+++ b/core/jazz_create-serverless-service/swagger/swagger.json
@@ -282,7 +282,6 @@
           "type": "string",
           "description": "The runtime framework for executing your code",
           "enum": [
-            "nodejs8.10",
             "nodejs10.x",
             "java8",
             "python3.6",

--- a/core/jazz_services/config/global-config.json
+++ b/core/jazz_services/config/global-config.json
@@ -132,7 +132,6 @@
   ],
   "SERVICE_RUNTIMES": [
     "nodejs10.x",
-    "nodejs8.10",
     "python3.6",
     "java8",
     "go1.x",

--- a/core/jazz_services/test/test.js
+++ b/core/jazz_services/test/test.js
@@ -68,7 +68,7 @@ describe('platform_services', function() {
         "domain" : "k!ngd0m",
         "region" : "mewni",
         "type" : "api",
-        "runtime" : "nodejs8.10",
+        "runtime" : "nodejs10.x",
         "created_by" : "g10$saryck",
         "status" : "active"
       },

--- a/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.html
+++ b/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.html
@@ -177,8 +177,8 @@
                             <section class="pad-left0 service-box-section" *ngIf="typeOfPlatform == 'aws'">
                                 <div tabindex="0" class="service-box" [ngClass]="{'service-box-selected': runtime == runtimeKeys[1]}"(keyup.enter)="onSelectionChange(runtimeKeys[1])"  (click)="onSelectionChange(runtimeKeys[1])">
                                     <div>
-                                        <img *ngIf="runtime == runtimeKeys[1]" [class.selected-image]="runtime == runtimeKeys[1]" src="./../../../assets/images/icons/nodejs.svg"/>
-                                        <img *ngIf="runtime != runtimeKeys[1]" [class.selected-image]="runtime == runtimeKeys[1]" src="./../../../../assets/images/icons/greyscale-icons/icon-nodejs.svg"/>
+                                        <img *ngIf="runtime == runtimeKeys[1]" [class.selected-image]="runtime == runtimeKeys[1]" src="./../../../assets/images/icons/python.svg"/>
+                                        <img *ngIf="runtime != runtimeKeys[1]" [class.selected-image]="runtime == runtimeKeys[1]" src="./../../../../assets/images/icons/greyscale-icons/icon-python.svg"/>
                                     </div>
                                 </div>
                                 <div class="icon-name" [ngClass]="{'service-box-selected': runtime == runtimeKeys[1]}">
@@ -188,8 +188,8 @@
                             <section class="pad-left0 service-box-section" *ngIf="typeOfPlatform == 'aws'">
                                 <div tabindex="0" class="service-box" [ngClass]="{'service-box-selected': runtime == runtimeKeys[2]}"(keyup.enter)="onSelectionChange(runtimeKeys[2])"  (click)="onSelectionChange(runtimeKeys[2])">
                                     <div class="icon-icon-python">
-                                        <img *ngIf="runtime == runtimeKeys[2]" [class.selected-image]="runtime == runtimeKeys[2]" src="./../../../assets/images/icons/python.svg"/>
-                                        <img *ngIf="runtime != runtimeKeys[2]" [class.selected-image]="runtime == runtimeKeys[2]" src="./../../../../assets/images/icons/greyscale-icons/icon-python.svg"/>
+                                        <img *ngIf="runtime == runtimeKeys[2]" [class.selected-image]="runtime == runtimeKeys[2]" src="./../../../assets/images/icons/Java.svg"/>
+                                        <img *ngIf="runtime != runtimeKeys[2]" [class.selected-image]="runtime == runtimeKeys[2]" src="./../../../../assets/images/icons/greyscale-icons/icon-java.svg"/>
                                     </div>
                                 </div>
                                 <div class="icon-name" [ngClass]="{'service-box-selected': runtime == runtimeKeys[2]}">
@@ -197,12 +197,12 @@
                                 </div>
                             </section>
                         </div>
-                        <div class="runtime-row2 run-type-width space-between">
+                        <div class="runtime-row2 run-type-width space-between contentSpace">
                             <section class="pad-left0 service-box-section" *ngIf="typeOfPlatform == 'aws'">
                                 <div tabindex="0" class="service-box"[ngClass]="{'service-box-selected': runtime == runtimeKeys[3]}"(keyup.enter)="onSelectionChange(runtimeKeys[3])"  (click)="onSelectionChange(runtimeKeys[3])">
                                     <div class="icon-icon-go">
-                                        <img *ngIf="runtime == runtimeKeys[3]" [class.selected-image]="runtime == runtimeKeys[3]" src="./../../../assets/images/icons/Java.svg"/>
-                                        <img *ngIf="runtime != runtimeKeys[3]" [class.selected-image]="runtime == runtimeKeys[3]" src="./../../../../assets/images/icons/greyscale-icons/icon-java.svg"/>
+                                        <img *ngIf="runtime == runtimeKeys[3]" [class.selected-image]="runtime == runtimeKeys[3]" src="./../../../assets/images/icons/Go.svg"/>
+                                        <img *ngIf="runtime != runtimeKeys[3]" [class.selected-image]="runtime == runtimeKeys[3]" src="./../../../../assets/images/icons/greyscale-icons/icon-go.svg"/>
                                     </div>
                                 </div>
                                 <div class="icon-name" [ngClass]="{'service-box-selected': runtime == runtimeKeys[3]}">
@@ -211,28 +211,16 @@
                             </section>
 
 
-                            <section class="pad-left0 service-box-section" *ngIf="typeOfPlatform == 'aws'">
+                            <section class="pad-left0 service-box-section disable-event" *ngIf="typeOfPlatform == 'aws'">
                                     <div tabindex="0" class="service-box" [ngClass]="{'service-box-selected': runtime == runtimeKeys[4]}"(keyup.enter)="onSelectionChange(runtimeKeys[4])"  (click)="onSelectionChange(runtimeKeys[4])">
                                         <div class="icon-icon-go">
-                                            <img *ngIf="runtime == runtimeKeys[4]" [class.selected-image]="runtime == runtimeKeys[4]" src="./../../../assets/images/icons/Go.svg"/>
-                                            <img *ngIf="runtime != runtimeKeys[4]" [class.selected-image]="runtime == runtimeKeys[4]" src="./../../../../assets/images/icons/greyscale-icons/icon-go.svg"/>
+                                            <img *ngIf="runtime == runtimeKeys[4]" [class.selected-image]="runtime == runtimeKeys[4]" src="./../../../assets/images/icons/C.svg"/>
+                                            <img *ngIf="runtime != runtimeKeys[4]" [class.selected-image]="runtime == runtimeKeys[4]" src="./../../../../assets/images/icons/greyscale-icons/icon-c.svg"/>
                                         </div>
                                     </div>
                                     <div class="icon-name" [ngClass]="{'service-box-selected': runtime == runtimeKeys[4]}">
                                         <p class="name-style">{{runtimeKeys[4]}}</p>
                                     </div>
-                            </section>
-
-                            <section class="pad-left0 service-box-section disable-event" *ngIf="typeOfPlatform == 'aws'">
-                                <div tabindex="0" class="service-box disabled-box" [ngClass]="{'service-box-selected': runtime == runtimeKeys[5]}" (keyup.enter)="onSelectionChange(runtimeKeys[5])" (click)="onSelectionChange(runtimeKeys[5])">
-                                    <div class="icon-icon-go">
-                                            <img  *ngIf="runtime == runtimeKeys[5]" [class.selected-image]="runtime == runtimeKeys[5]" src="./../../../assets/images/icons/C.svg"/>
-                                            <img  *ngIf="runtime != runtimeKeys[5]" [class.selected-image]="runtime == runtimeKeys[5]" src="./../../../../assets/images/icons/greyscale-icons/icon-c.svg"/>
-                                    </div>
-                                </div>
-                                <div class="icon-name" [ngClass]="{'service-box-selected': runtime == runtimeKeys[5]}">
-                                    <p class="name-style">C#</p>
-                                </div>
                             </section>
 
                         </div>

--- a/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.scss
+++ b/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.scss
@@ -20,6 +20,9 @@
   height: 20px;
   padding: 10px 10px;
 }
+.runtime-row2.contentSpace{
+  width: 41%
+}
 
 .create-service-wrap .bold-title {
   padding: 1.33rem 0;

--- a/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.ts
+++ b/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.ts
@@ -467,7 +467,6 @@ export class CreateServiceComponent implements OnInit {
       switch(this.runtime){
 
         case 'java8' : this.deploymentDescriptorText = this.deploymentDescriptorTextJava; break;
-        case 'nodejs8.10' : this.deploymentDescriptorText = this.deploymentDescriptorTextNodejs; break;
         case 'nodejs10.x' : this.deploymentDescriptorText = this.deploymentDescriptorTextNodejs; break;
         case 'go1.x' : this.deploymentDescriptorText = this.deploymentDescriptorTextgo; break;
         case 'python3.6' : this.deploymentDescriptorText = this.deploymentDescriptorTextpython; break;

--- a/core/jazz_ui/src/environments/environment.oss.ts
+++ b/core/jazz_ui/src/environments/environment.oss.ts
@@ -8,7 +8,7 @@ export const environment = {
   multi_env: {multi_env},
   slack_support: {slack_support},
   webLists: { "html": "Static", "angular": "Angular", "react": "ReactJS" },
-  envLists: { "nodejs10.x": "Nodejs 10.x", "nodejs8.10": "Nodejs 8.10", "python3.6": "Python 3.6", "java8": "Java 8", "go1.x": "Go 1.x", "c#": "C#" },
+  envLists: { "nodejs10.x": "Nodejs 10.x", "python3.6": "Python 3.6", "java8": "Java 8", "go1.x": "Go 1.x", "c#": "C#" },
   serviceTabs: ["{overview}", "{access control}", "{metrics}", "{logs}", "{cost}"],
   environmentTabs: ["{env_overview}", "{deployments}", "{code quality}", "{metrics}", "{assets}", "{env_logs}"],
   assetTypeList: [
@@ -55,7 +55,7 @@ export const environment = {
   aws: {
     account_number: '{account_number}',
     region: '{region}',
-    envLists: {"nodejs10.x": "Nodejs 10.x", "nodejs8.10": "Nodejs 8.10", "python3.6": "Python 3.6", "java8": "Java 8", "go1.x": "Go 1.x"},
+    envLists: {"nodejs10.x": "Nodejs 10.x", "python3.6": "Python 3.6", "java8": "Java 8", "go1.x": "Go 1.x"},
     accountMap: {accountMap},
     default_region: '{default_region}',
     default_account: '{default_account}'
@@ -64,7 +64,7 @@ export const environment = {
     azure_account_number: '{azure_account_number}',
     azure_region: '{azure_region}',
     azure_enabled: {azure_enabled},
-    envLists: {"nodejs8.10": "Nodejs 8.10", "c#": "C#"},
+    envLists: {"nodejs10.x": "Nodejs 10.x", "c#": "C#"},
   },
   gcloud: {
     envLists:  {},


### PR DESCRIPTION
### Requirements

Removing support for nodejs8 runtime since it reached end-of-life date based on AWS [docs](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html).

### Description of the Change

Removing support for nodejs8 during service creation and builds for old services using nodejs8 as runtime forcing users to use the new version.
