### PR TITLE
🐛 Fix logic that identifies gitlab events correctly

### DIFF
--- a/core/jazz_environment-event-handler/package.json
+++ b/core/jazz_environment-event-handler/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "string-template": "*",
-        "nanoid": "*",
+        "nanoid": "2.1.11",
         "request": "*",
         "request-promise-native": "^1.0.5"
     },

--- a/core/jazz_scm-webhook/index.js
+++ b/core/jazz_scm-webhook/index.js
@@ -241,7 +241,7 @@ var gitlabScmContextDetails = function (eventKey, body, config) {
 			var branch = origins[2];
 			result.branch = branch;
 
-			if (body.before && parseInt(body.before, 10) === 0) {
+			if (body.before && body.before === '0000000000000000000000000000000000000000') {
 				if (eventKey === 'tag_push') {
 					result.event_name = 'CREATE_TAG';
 					resolve(result);
@@ -253,7 +253,7 @@ var gitlabScmContextDetails = function (eventKey, body, config) {
 					result.event_name = 'CREATE_BRANCH';
 					resolve(result);
 				}
-			} else if (body.after && parseInt(body.after, 10) === 0) {
+			} else if (body.after && body.after === '0000000000000000000000000000000000000000') {
 				if (eventKey === 'tag_push') {
 					result.event_name = 'DELETE_TAG';
 					resolve(result);


### PR DESCRIPTION
### Requirements

Fix logic that identifies gitlab events.

### Description of the Change

`parseInt (event.data, 10) === 0` is true whenever commit hash starts with 0 (ex: 0ade6c45bac499a6642a4fae90edeb743595fe4d). This may incorrectly identify a gitlab event as branch creation/deletion event instead of a simple commit event. 

Based on gitlab's source [code](https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/doc/api/merge_requests.md#create-mr-pipeline), it looks like `0000000000000000000000000000000000000000`  is used to identify initial/final state.

### Benefits

Correctly identifies the gitlab event type.
