### PR TITLE
Feature: Support latest runtimes for AWS Lambda

### DIFF
--- a/builds/delete-serverless-service-build-pack/Jenkinsfile
+++ b/builds/delete-serverless-service-build-pack/Jenkinsfile
@@ -217,7 +217,9 @@ node {
 									events.sendStartedEvent('DELETE_ENVIRONMENT', "Environment cleanup for " + _envId + " started", null, _envId)
 									echo 'undeploying service for environment: ' + _envId
 									
-									vaultUtilityModule.setEnvironmentLogicalId(_envId)
+									if (configLoader.TVAULT && configLoader.TVAULT.IS_ENABLED instanceof Boolean && configLoader.TVAULT.IS_ENABLED) {
+										vaultUtilityModule.setEnvironmentLogicalId(_envId)
+									}
 									
 									switch(apiPlatform) {
 										case 'aws_apigateway':
@@ -270,7 +272,9 @@ node {
 									events.setEnvironment(_envId)
 									events.sendStartedEvent('DELETE_ENVIRONMENT', "Environment cleanup for " + _envId + " started", null, _envId)
 									
-									vaultUtilityModule.setEnvironmentLogicalId(_envId)
+									if (configLoader.TVAULT && configLoader.TVAULT.IS_ENABLED instanceof Boolean && configLoader.TVAULT.IS_ENABLED) {
+										vaultUtilityModule.setEnvironmentLogicalId(_envId)
+									}
 
 									if (service_config['event_source_s3']) { // check service for S3 Bucket and make empty if not. //
 										checkBucket(current_environment_id);
@@ -347,7 +351,9 @@ node {
 									events.sendStartedEvent('DELETE_ENVIRONMENT', "Environment cleanup for " + _envId + " started", null, _envId)
 									echo 'undeploying sls service for environment: ' + _envId
 
-									vaultUtilityModule.setEnvironmentLogicalId(_envId)
+									if (configLoader.TVAULT && configLoader.TVAULT.IS_ENABLED instanceof Boolean && configLoader.TVAULT.IS_ENABLED) {
+										vaultUtilityModule.setEnvironmentLogicalId(_envId)
+									}
 
 									cleanupEventSourceMapping(_envId)
 									if (has_serverless_yml) {

--- a/builds/jazz-build-module/sls-app/serverless-build-rules.yml
+++ b/builds/jazz-build-module/sls-app/serverless-build-rules.yml
@@ -70,8 +70,11 @@ provider:
     sbr-constraint:
       sbr-enum:
         - nodejs10.x
+        - nodejs12.x
         - java8
+        - java11
         - python3.6
+        - python3.8
         - go1.x
     sbr-value:
       sbr-formula: ${config.providerRuntime}
@@ -581,8 +584,11 @@ function:
       sbr-constraint:
         sbr-enum:
           - nodejs10.x
+          - nodejs12.x
           - java8
+          - java11
           - python3.6
+          - python3.8
           - go1.x
       sbr-value:
         sbr-formula: ${config.providerRuntime}

--- a/builds/jenkins-build-pack-api/Jenkinsfile
+++ b/builds/jenkins-build-pack-api/Jenkinsfile
@@ -728,7 +728,7 @@ def buildLambda(String runtime, String repo_name) {
     sh "rm -rf library"
     sh "mkdir library"
     sh "touch library/__init__.py"
-    if (runtime == 'python3.6') {
+    if (runtime == 'python3.6' || runtime == 'python3.8') {
       //Installing dependencies
       sh "pip3 install -r requirements.txt -t library"
       // create virtual environment and install pytest
@@ -909,7 +909,7 @@ def validateDeploymentConfigurations(def prop) {
       error "Wrong configuration. Value for Key 'providerRuntime' is missing in the configuration"
 
     } else {
-      def validRuntimes = ["nodejs10.x", "python3.6", "java8", "go1.x"]
+      def validRuntimes = ["nodejs10.x", "nodejs12.x", "python3.6", "python3.8", "java8", "java11", "go1.x"]
       def flag = false
       for (int i = 0; i < validRuntimes.size(); i++) {
         if (_runtime == validRuntimes[i]) {

--- a/builds/jenkins-build-pack-function/Jenkinsfile
+++ b/builds/jenkins-build-pack-function/Jenkinsfile
@@ -702,7 +702,7 @@ def buildFunction(String runtime, String repo_name) {
     sh "mkdir library"
     sh "touch library/__init__.py"
 
-    if (runtime == 'python3.6'){
+    if (runtime == 'python3.6' || runtime == 'python3.8'){
       // Installing dependencies
       sh "pip3 install -r requirements.txt -t library"
       // create virtual environment and install pytest
@@ -761,7 +761,7 @@ def validateDeploymentConfigurations(def prop) {
     if (_runtime == "") {
       error "Wrong configuration. Value for Key 'providerRuntime' is missing in the configuration"
     } else {
-      def validRuntimes = ["nodejs10.x", "python3.6", "java8", "go1.x", "c#"]
+      def validRuntimes = ["nodejs10.x", "nodejs12.x", "python3.6", "python3.8", "java8", "java11", "go1.x", "c#"]
       def flag = false
 
       for (int i = 0; i < validRuntimes.size(); i++) {

--- a/builds/jenkins-build-pack-sls-app/Jenkinsfile
+++ b/builds/jenkins-build-pack-sls-app/Jenkinsfile
@@ -590,7 +590,7 @@ def buildSlsApp(String runtime, String repo_name) {
     //Installing dependencies
     sh "pip install -r requirements.txt -t library"
     sh "touch library/__init__.py"
-    if (runtime == 'python3.6') {
+    if (runtime == 'python3.6' || runtime == 'python3.8') {
       // create virtual environment and install pytest
       sh """
       python3 -m venv virtualenv
@@ -655,7 +655,7 @@ def validateDeploymentConfigurations(def prop) {
     if (_runtime == "") {
       error "Wrong configuration. Value for Key 'providerRuntime' is missing in the configuration"
     } else {
-      def validRuntimes = ["nodejs10.x", "python3.6", "java8", "go1.x"]
+      def validRuntimes = ["nodejs10.x", "nodejs12.x", "python3.6", "python3.8", "java8", "java11", "go1.x"]
       def flag = false
 
       for (int i = 0; i < validRuntimes.size(); i++) {

--- a/core/jazz_create-serverless-service/swagger/swagger.json
+++ b/core/jazz_create-serverless-service/swagger/swagger.json
@@ -283,8 +283,11 @@
           "description": "The runtime framework for executing your code",
           "enum": [
             "nodejs10.x",
+            "nodejs12.x",
             "java8",
+            "java11",
             "python3.6",
+            "python3.8",
             "go1.x"
           ]
         },

--- a/core/jazz_services/config/global-config.json
+++ b/core/jazz_services/config/global-config.json
@@ -132,8 +132,11 @@
   ],
   "SERVICE_RUNTIMES": [
     "nodejs10.x",
+    "nodejs12.x",
     "python3.6",
+    "python3.8",
     "java8",
+    "java11",
     "go1.x",
     "c#"
   ],

--- a/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.ts
+++ b/core/jazz_ui/src/app/secondary-components/create-service/oss/create-service.component.ts
@@ -466,10 +466,13 @@ export class CreateServiceComponent implements OnInit {
     if(!this.startNew){
       switch(this.runtime){
 
-        case 'java8' : this.deploymentDescriptorText = this.deploymentDescriptorTextJava; break;
-        case 'nodejs10.x' : this.deploymentDescriptorText = this.deploymentDescriptorTextNodejs; break;
+        case 'java8' : 
+        case 'java11': this.deploymentDescriptorText = this.deploymentDescriptorTextJava; break;
+        case 'nodejs10.x' : 
+        case 'nodejs12.x' : this.deploymentDescriptorText = this.deploymentDescriptorTextNodejs; break;
         case 'go1.x' : this.deploymentDescriptorText = this.deploymentDescriptorTextgo; break;
-        case 'python3.6' : this.deploymentDescriptorText = this.deploymentDescriptorTextpython; break;
+        case 'python3.6' : 
+        case 'python3.8' : this.deploymentDescriptorText = this.deploymentDescriptorTextpython; break;
         case 'c#' : this.deploymentDescriptorText = this.deploymentDescriptorTextpython; break;
       }
     }

--- a/core/jazz_ui/src/environments/environment.oss.ts
+++ b/core/jazz_ui/src/environments/environment.oss.ts
@@ -8,7 +8,8 @@ export const environment = {
   multi_env: {multi_env},
   slack_support: {slack_support},
   webLists: { "html": "Static", "angular": "Angular", "react": "ReactJS" },
-  envLists: { "nodejs10.x": "Nodejs 10.x", "python3.6": "Python 3.6", "java8": "Java 8", "go1.x": "Go 1.x", "c#": "C#" },
+  envLists: {"nodejs12.x": "Nodejs 12.x", "python3.8": "Python 3.8", "java11": "Java 11", "go1.x": "Go 1.x", "c#": "C#" },
+  runtimeLists: {"nodejs": ["Nodejs 10.x", "Nodejs 12.x"], "python": ["Python 3.6", "Python 3.8"], "java": ["Java 8", "Java 11"], "go": ["Go 1.x"], "c": ["C#"]},
   serviceTabs: ["{overview}", "{access control}", "{metrics}", "{logs}", "{cost}"],
   environmentTabs: ["{env_overview}", "{deployments}", "{code quality}", "{metrics}", "{assets}", "{env_logs}"],
   assetTypeList: [
@@ -55,7 +56,7 @@ export const environment = {
   aws: {
     account_number: '{account_number}',
     region: '{region}',
-    envLists: {"nodejs10.x": "Nodejs 10.x", "python3.6": "Python 3.6", "java8": "Java 8", "go1.x": "Go 1.x"},
+    envLists: {"nodejs12.x": "Nodejs 12.x", "python3.8": "Python 3.8", "java11": "Java 11", "go1.x": "Go 1.x", "c#": "C#"},
     accountMap: {accountMap},
     default_region: '{default_region}',
     default_account: '{default_account}'

--- a/templates/api-template-java/pom.xml
+++ b/templates/api-template-java/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### Requirements

Developers should be able to select and use latest runtime versions supported by AWS Lambda when serverless applications/functions using Jazz.

### Description of the Change

- Updated UI to allow developers to select latest runtime versions
- Updated  build-packs to support latest runtimes

### Benefits
Developers will be able to use the latest runtime versions supported by AWS Lambda 

